### PR TITLE
feat(burger): animated menu-toggle component

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ export class AppComponent {
 
 **Layout** — [card](https://ngwr.dev/components/card), [carousel](https://ngwr.dev/components/carousel), [collapse](https://ngwr.dev/components/collapse), [layout](https://ngwr.dev/components/layout), [list](https://ngwr.dev/components/list), [page-header](https://ngwr.dev/components/page-header), [splitter](https://ngwr.dev/components/splitter), [toolbar](https://ngwr.dev/components/toolbar).
 
-**Navigation** — [anchor](https://ngwr.dev/components/anchor), [back-top](https://ngwr.dev/components/back-top), [breadcrumbs](https://ngwr.dev/components/breadcrumbs), [dropdown](https://ngwr.dev/components/dropdown), [sidebar](https://ngwr.dev/components/sidebar), [stepper](https://ngwr.dev/components/stepper), [tabs](https://ngwr.dev/components/tabs).
+**Navigation** — [anchor](https://ngwr.dev/components/anchor), [back-top](https://ngwr.dev/components/back-top), [breadcrumbs](https://ngwr.dev/components/breadcrumbs), [burger](https://ngwr.dev/components/burger), [dropdown](https://ngwr.dev/components/dropdown), [sidebar](https://ngwr.dev/components/sidebar), [stepper](https://ngwr.dev/components/stepper), [tabs](https://ngwr.dev/components/tabs).
 
 **Overlays** — [command-palette](https://ngwr.dev/components/command-palette), [context-menu](https://ngwr.dev/components/context-menu), [dialog](https://ngwr.dev/components/dialog), [drawer](https://ngwr.dev/components/drawer), [popconfirm](https://ngwr.dev/components/popconfirm), [popover](https://ngwr.dev/components/popover), [toast](https://ngwr.dev/components/toast), [window](https://ngwr.dev/components/window).
 

--- a/projects/lib/burger/burger.html
+++ b/projects/lib/burger/burger.html
@@ -1,0 +1,20 @@
+<button
+  type="button"
+  class="wr-burger__btn"
+  [attr.aria-expanded]="open()"
+  [attr.aria-label]="label()"
+  [disabled]="disabled()"
+  (click)="toggle()"
+>
+  <svg class="wr-burger__icon" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path
+      class="wr-burger__line wr-burger__line--1"
+      d="M 20,29 H 80 C 80,29 94.5,28.8 94.5,66.7 94.5,78 91,81.7 85.3,81.7 79.6,81.7 75,75 75,75 L 25,25"
+    />
+    <path class="wr-burger__line wr-burger__line--2" d="M 20,50 H 80" />
+    <path
+      class="wr-burger__line wr-burger__line--3"
+      d="M 20,71 H 80 C 80,71 94.5,71.2 94.5,33.3 94.5,22 91,18.3 85.3,18.3 79.6,18.3 75,25 75,25 L 25,75"
+    />
+  </svg>
+</button>

--- a/projects/lib/burger/burger.ts
+++ b/projects/lib/burger/burger.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/thekhegay/ngwr/blob/main/LICENSE
+ */
+
+import { coerceBooleanProperty } from '@angular/cdk/coercion';
+import { Component, ViewEncapsulation, computed, input, model } from '@angular/core';
+
+/**
+ * Animated menu toggle — three SVG strokes morph between a hamburger and a
+ * close mark on `open`. Two-way bindable, so it pairs naturally with a
+ * `<wr-drawer>` or any disclosure.
+ *
+ * The morph is pure CSS (`stroke-dasharray` / `stroke-dashoffset` tweens),
+ * so it stays smooth without JS and collapses to its end state under
+ * `prefers-reduced-motion`.
+ *
+ * @example Toggle a drawer
+ * ```html
+ * <wr-burger [(open)]="menuOpen" />
+ * <wr-drawer [(open)]="menuOpen" position="right">…</wr-drawer>
+ * ```
+ *
+ * @see https://ngwr.dev/components/burger
+ */
+@Component({
+  selector: 'wr-burger',
+  templateUrl: './burger.html',
+  encapsulation: ViewEncapsulation.None,
+  host: { '[class]': 'classes()' },
+})
+export class WrBurger {
+  /** Two-way bindable open state. Drives the hamburger ↔ close morph. @default false */
+  readonly open = model(false);
+
+  /** Accessible label for the toggle button. @default 'Toggle menu' */
+  readonly label = input('Toggle menu');
+
+  /** Disable the toggle. @default false */
+  readonly disabled = input(false, { transform: coerceBooleanProperty });
+
+  protected readonly classes = computed(() => ({
+    'wr-burger': true,
+    'wr-burger--opened': this.open(),
+  }));
+
+  protected toggle(): void {
+    if (this.disabled()) return;
+    this.open.set(!this.open());
+  }
+}

--- a/projects/lib/burger/index.ts
+++ b/projects/lib/burger/index.ts
@@ -1,0 +1,1 @@
+export * from './public-api';

--- a/projects/lib/burger/ng-package.json
+++ b/projects/lib/burger/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "public-api.ts"
+  }
+}

--- a/projects/lib/burger/public-api.ts
+++ b/projects/lib/burger/public-api.ts
@@ -1,0 +1,1 @@
+export { WrBurger } from './burger';

--- a/projects/lib/burger/styles/_index.scss
+++ b/projects/lib/burger/styles/_index.scss
@@ -1,0 +1,101 @@
+@use '../../theme/styles' as theme;
+
+.wr-burger {
+  // Resting (hamburger) dash geometry. Each line is one SVG <path>; the
+  // open state below rewrites the dasharray/offset so the strokes slide
+  // into a close mark.
+  --wr-burger-size: 2.5rem;
+  --wr-burger-color: var(--wr-color-dark);
+  --wr-burger-color-opened: var(--wr-color-primary);
+  --wr-burger-stroke-width: 6px;
+  --wr-burger-duration: 0.5s;
+  --wr-burger-ease: var(--wr-ease-in-out);
+
+  --wr-burger-stroke-1: 60 207;
+  --wr-burger-offset-1: 0;
+  --wr-burger-stroke-2: 60 60;
+  --wr-burger-offset-2: 0;
+  --wr-burger-stroke-3: 60 207;
+  --wr-burger-offset-3: 0;
+
+  display: inline-flex;
+
+  &__btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    width: var(--wr-burger-size);
+    height: var(--wr-burger-size);
+    padding: 0;
+
+    border: 0;
+    border-radius: var(--wr-border-radius-base);
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+
+    transition: background var(--wr-transition-base);
+
+    &:hover {
+      background: rgba(var(--wr-color-light-rgb), 0.4);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--wr-color-primary);
+      outline-offset: 2px;
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+  }
+
+  &__icon {
+    display: block;
+    width: 80%;
+    height: 80%;
+  }
+
+  &__line {
+    fill: none;
+    stroke: var(--wr-burger-color);
+    stroke-width: var(--wr-burger-stroke-width);
+    transition:
+      stroke-dasharray var(--wr-burger-duration) var(--wr-burger-ease),
+      stroke-dashoffset var(--wr-burger-duration) var(--wr-burger-ease),
+      stroke var(--wr-burger-duration) var(--wr-burger-ease);
+
+    &--1 {
+      stroke-dasharray: var(--wr-burger-stroke-1);
+      stroke-dashoffset: var(--wr-burger-offset-1);
+    }
+
+    &--2 {
+      stroke-dasharray: var(--wr-burger-stroke-2);
+      stroke-dashoffset: var(--wr-burger-offset-2);
+    }
+
+    &--3 {
+      stroke-dasharray: var(--wr-burger-stroke-3);
+      stroke-dashoffset: var(--wr-burger-offset-3);
+    }
+  }
+
+  &--opened {
+    --wr-burger-color: var(--wr-burger-color-opened);
+    --wr-burger-stroke-1: 90 207;
+    --wr-burger-offset-1: -134;
+    --wr-burger-stroke-2: 1 60;
+    --wr-burger-offset-2: -30;
+    --wr-burger-stroke-3: 90 207;
+    --wr-burger-offset-3: -134;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .wr-burger__line {
+      transition-duration: 1ms;
+    }
+  }
+}

--- a/projects/lib/package.json
+++ b/projects/lib/package.json
@@ -2,7 +2,7 @@
   "name": "ngwr",
   "version": "7.0.0",
   "license": "MIT",
-  "description": "NGWR – Angular UI components library",
+  "description": "NGWR \u2013 Angular UI components library",
   "author": "Roman Khegay <rk@garuna.dev> (https://garuna.dev)",
   "keywords": [
     "ngwr",
@@ -108,6 +108,9 @@
     },
     "./breadcrumbs": {
       "sass": "./breadcrumbs/styles/_index.scss"
+    },
+    "./burger": {
+      "sass": "./burger/styles/_index.scss"
     },
     "./button": {
       "sass": "./button/styles/_index.scss"

--- a/projects/lib/styles.scss
+++ b/projects/lib/styles.scss
@@ -27,6 +27,7 @@
 @forward './blur-text/styles';
 @forward './border-glow/styles';
 @forward './breadcrumbs/styles';
+@forward './burger/styles';
 @forward './button/styles';
 @forward './calendar/styles';
 @forward './calendar-heatmap/styles';

--- a/projects/showcase/app/_layout/sidebar/configs/components.config.ts
+++ b/projects/showcase/app/_layout/sidebar/configs/components.config.ts
@@ -100,6 +100,7 @@ export const COMPONENTS_SIDEBAR: readonly SidebarGroup[] = [
       { title: 'Anchor', url: ['/components', 'anchor'] },
       { title: 'Back to Top', url: ['/components', 'back-top'] },
       { title: 'Breadcrumbs', url: ['/components', 'breadcrumbs'] },
+      { title: 'Burger', url: ['/components', 'burger'] },
       { title: 'Dropdown', url: ['/components', 'dropdown'] },
       { title: 'Sidebar', url: ['/components', 'sidebar'] },
       { title: 'Stepper', url: ['/components', 'stepper'] },

--- a/projects/showcase/app/components/burger/burger.html
+++ b/projects/showcase/app/components/burger/burger.html
@@ -1,0 +1,60 @@
+<ngwr-doc-page
+  title="Burger"
+  description="Animated menu toggle — three SVG strokes morph between a hamburger and a close mark. Two-way bindable, so it pairs naturally with a `<wr-drawer>`."
+  [keywords]="['burger', 'hamburger', 'menu-toggle', 'wr-burger']"
+  [labels]="['Component', 'Standalone']"
+>
+  <ngwr-doc-section
+    title="Basic usage"
+    description="Click to morph between the hamburger and close marks. The `open` state is two-way bindable."
+  >
+    <ngwr-doc-snippet code="">
+      <wr-burger [(open)]="open" />
+      <span style="margin-inline-start: 1rem; color: var(--wr-color-medium); font-size: 0.875rem">
+        open: {{ open() }}
+      </span>
+    </ngwr-doc-snippet>
+    <ngwr-doc-code [code]="basicSnippet" language="angular-html" />
+  </ngwr-doc-section>
+
+  <ngwr-doc-section
+    title="With a drawer"
+    description="The canonical pairing — bind the same signal to `<wr-burger>` and `<wr-drawer>`. The button morphs to a close mark while the menu is open, and tapping it again closes the menu."
+  >
+    <ngwr-doc-snippet code="">
+      <wr-burger [(open)]="drawerOpen" />
+      <wr-drawer [(open)]="drawerOpen" position="right" width="16rem">
+        <div style="display: flex; flex-direction: column; gap: 0.25rem; padding: 1.25rem 1rem">
+          <a style="padding: 0.625rem 0.75rem; border-radius: 0.375rem; font-weight: 600">Dashboard</a>
+          <a style="padding: 0.625rem 0.75rem; border-radius: 0.375rem; font-weight: 600">Projects</a>
+          <a style="padding: 0.625rem 0.75rem; border-radius: 0.375rem; font-weight: 600">Settings</a>
+        </div>
+      </wr-drawer>
+    </ngwr-doc-snippet>
+    <ngwr-doc-code [code]="drawerSnippet" language="angular-html" />
+  </ngwr-doc-section>
+
+  <ngwr-doc-section
+    title="Styling"
+    description="Size, colors, stroke width, and morph duration are all CSS custom properties — override them inline or in a stylesheet."
+  >
+    <ngwr-doc-snippet code="">
+      <wr-burger [(open)]="open" style="--wr-burger-size: 3rem; --wr-burger-color-opened: var(--wr-color-danger)" />
+    </ngwr-doc-snippet>
+    <ngwr-doc-code [code]="stylingSnippet" language="angular-html" />
+  </ngwr-doc-section>
+
+  <ngwr-doc-section title="Disabled" description="A disabled toggle ignores clicks and dims.">
+    <ngwr-doc-snippet code="">
+      <wr-burger [(open)]="disabledOpen" disabled />
+    </ngwr-doc-snippet>
+  </ngwr-doc-section>
+
+  <ngwr-doc-section title="API">
+    <ngwr-doc-api [rows]="api" />
+  </ngwr-doc-section>
+
+  <ngwr-doc-section title="CSS variables">
+    <ngwr-doc-api [rows]="tokens" />
+  </ngwr-doc-section>
+</ngwr-doc-page>

--- a/projects/showcase/app/components/burger/burger.ts
+++ b/projects/showcase/app/components/burger/burger.ts
@@ -1,0 +1,69 @@
+import { Component, signal } from '@angular/core';
+
+import { WrBurger } from 'ngwr/burger';
+import { WrDrawer } from 'ngwr/drawer';
+
+import {
+  type DocApiRow,
+  DocApiComponent,
+  DocCodeComponent,
+  DocPageComponent,
+  DocSectionComponent,
+  DocSnippetComponent,
+} from '#core/components';
+
+@Component({
+  selector: 'ngwr-burger-page',
+  templateUrl: './burger.html',
+  imports: [
+    WrBurger,
+    WrDrawer,
+    DocPageComponent,
+    DocSectionComponent,
+    DocCodeComponent,
+    DocSnippetComponent,
+    DocApiComponent,
+  ],
+})
+export default class BurgerPage {
+  protected readonly open = signal(false);
+  protected readonly drawerOpen = signal(false);
+  protected readonly disabledOpen = signal(false);
+
+  protected readonly basicSnippet = `<wr-burger [(open)]="menuOpen" />`;
+
+  protected readonly drawerSnippet = `<wr-burger [(open)]="menuOpen" />
+
+<wr-drawer [(open)]="menuOpen" position="right" width="16rem">
+  <!-- nav links… -->
+</wr-drawer>`;
+
+  protected readonly stylingSnippet = `<wr-burger
+  [(open)]="menuOpen"
+  style="--wr-burger-size: 3rem; --wr-burger-color-opened: var(--wr-color-danger);"
+/>`;
+
+  protected readonly api: readonly DocApiRow[] = [
+    {
+      name: 'open',
+      description: 'Two-way bindable open state. Drives the hamburger ↔ close morph.',
+      type: 'model<boolean>',
+      default: 'false',
+    },
+    { name: 'label', description: 'Accessible label for the toggle button.', type: 'string', default: "'Toggle menu'" },
+    { name: 'disabled', description: 'Disable the toggle.', type: 'boolean', default: 'false' },
+  ];
+
+  protected readonly tokens: readonly DocApiRow[] = [
+    { name: '--wr-burger-size', description: 'Button square size.', type: 'length', default: '2.5rem' },
+    { name: '--wr-burger-color', description: 'Resting stroke color.', type: 'color', default: 'var(--wr-color-dark)' },
+    {
+      name: '--wr-burger-color-opened',
+      description: 'Stroke color when open.',
+      type: 'color',
+      default: 'var(--wr-color-primary)',
+    },
+    { name: '--wr-burger-stroke-width', description: 'Line thickness.', type: 'length', default: '6px' },
+    { name: '--wr-burger-duration', description: 'Morph duration.', type: 'time', default: '0.5s' },
+  ];
+}

--- a/projects/showcase/app/components/components.routing.ts
+++ b/projects/showcase/app/components/components.routing.ts
@@ -35,6 +35,10 @@ export default [
     loadComponent: () => import('./breadcrumbs/breadcrumbs'),
   },
   {
+    path: components.burger,
+    loadComponent: () => import('./burger/burger'),
+  },
+  {
     path: components.button,
     loadComponent: () => import('./button/button'),
   },

--- a/projects/showcase/app/routing.ts
+++ b/projects/showcase/app/routing.ts
@@ -56,6 +56,7 @@ export const routes = {
     backTop: 'back-top',
     badge: 'badge',
     breadcrumbs: 'breadcrumbs',
+    burger: 'burger',
     button: 'button',
     buttonGroup: 'button-group',
     calendar: 'calendar',


### PR DESCRIPTION
New `ngwr/burger` — three SVG strokes morph hamburger ↔ close via pure-CSS `stroke-dasharray`/`dashoffset` tweens. Two-way `open`, `label`/`disabled`, real `<button>` with `aria-expanded`, reduced-motion safe, fully tokenized (`--wr-burger-*`). Showcase page + route + sidebar + README. Lint + builds green.