### PR TITLE
feat(popover): add left/right start and end position variants

### DIFF
--- a/projects/lib/popover/interfaces/popover-position.ts
+++ b/projects/lib/popover/interfaces/popover-position.ts
@@ -15,7 +15,11 @@ export type WrPopoverPosition =
   | 'bottom-start'
   | 'bottom-end'
   | 'left'
-  | 'right';
+  | 'left-start'
+  | 'left-end'
+  | 'right'
+  | 'right-start'
+  | 'right-end';
 
 /** @internal */
 export const WR_POPOVER_POSITIONS: Record<WrPopoverPosition, ConnectedPosition[]> = {
@@ -26,5 +30,9 @@ export const WR_POPOVER_POSITIONS: Record<WrPopoverPosition, ConnectedPosition[]
   'bottom-start': [{ originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 8 }],
   'bottom-end': [{ originX: 'end', originY: 'bottom', overlayX: 'end', overlayY: 'top', offsetY: 8 }],
   left: [{ originX: 'start', originY: 'center', overlayX: 'end', overlayY: 'center', offsetX: -8 }],
+  'left-start': [{ originX: 'start', originY: 'top', overlayX: 'end', overlayY: 'top', offsetX: -8 }],
+  'left-end': [{ originX: 'start', originY: 'bottom', overlayX: 'end', overlayY: 'bottom', offsetX: -8 }],
   right: [{ originX: 'end', originY: 'center', overlayX: 'start', overlayY: 'center', offsetX: 8 }],
+  'right-start': [{ originX: 'end', originY: 'top', overlayX: 'start', overlayY: 'top', offsetX: 8 }],
+  'right-end': [{ originX: 'end', originY: 'bottom', overlayX: 'start', overlayY: 'bottom', offsetX: 8 }],
 };

--- a/projects/lib/popover/styles/_index.scss
+++ b/projects/lib/popover/styles/_index.scss
@@ -70,10 +70,26 @@
   right: -3px;
   margin-top: -3px;
 }
+.wr-tooltip-overlay--left-start .wr-tooltip::after {
+  top: 0.625rem;
+  right: -3px;
+}
+.wr-tooltip-overlay--left-end .wr-tooltip::after {
+  bottom: 0.625rem;
+  right: -3px;
+}
 .wr-tooltip-overlay--right .wr-tooltip::after {
   top: 50%;
   left: -3px;
   margin-top: -3px;
+}
+.wr-tooltip-overlay--right-start .wr-tooltip::after {
+  top: 0.625rem;
+  left: -3px;
+}
+.wr-tooltip-overlay--right-end .wr-tooltip::after {
+  bottom: 0.625rem;
+  left: -3px;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/projects/showcase/app/components/popover/popover.html
+++ b/projects/showcase/app/components/popover/popover.html
@@ -39,7 +39,9 @@
     <ngwr-doc-snippet [code]="snippets.positions">
       <wr-btn [wrPopover]="hint" position="bottom-start">Bottom start</wr-btn>
       <wr-btn [wrPopover]="hint" position="top-end">Top end</wr-btn>
-      <wr-btn [wrPopover]="hint" position="right">Right</wr-btn>
+      <wr-btn [wrPopover]="hint" position="left-start">Left start</wr-btn>
+      <wr-btn [wrPopover]="hint" position="right-start">Right start</wr-btn>
+      <wr-btn [wrPopover]="hint" position="right-end">Right end</wr-btn>
 
       <ng-template #hint>
         <div style="padding: 0.625rem 0.875rem; font-size: 0.8125rem">CDK auto-flips if there's no room.</div>

--- a/projects/showcase/app/components/popover/popover.ts
+++ b/projects/showcase/app/components/popover/popover.ts
@@ -75,8 +75,9 @@ export class MyComponent {}`,
     },
     {
       name: 'position',
-      description: 'Anchor side. Defaults differ by mode (`bottom` for popover, `top` for tooltip).',
-      type: "'top' | 'top-start' | 'top-end' | 'bottom' | 'bottom-start' | 'bottom-end' | 'left' | 'right'",
+      description:
+        'Anchor side, with optional `-start`/`-end` edge alignment. Defaults differ by mode (`bottom` for popover, `top` for tooltip).',
+      type: "'top' | 'top-start' | 'top-end' | 'bottom' | 'bottom-start' | 'bottom-end' | 'left' | 'left-start' | 'left-end' | 'right' | 'right-start' | 'right-end'",
       default: 'null',
     },
     {


### PR DESCRIPTION
Adds `left-start` / `left-end` / `right-start` / `right-end` so left/right reach full `-start`/`-end` parity with top/bottom — for placing a popover beside a tall trigger aligned to its top/bottom edge. New CDK position configs + per-variant tooltip arrows + showcase demos. Verified `right-start` geometry. Lint + builds green.