### PR TITLE
feat(meta): reactive bind() for locale-aware title

### DIFF
--- a/projects/lib/meta/wr-meta.ts
+++ b/projects/lib/meta/wr-meta.ts
@@ -6,7 +6,7 @@
  */
 
 import { DOCUMENT } from '@angular/common';
-import { Service, computed, inject, signal } from '@angular/core';
+import { Injector, Service, computed, effect, inject, signal, untracked } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
 
 import type { WrMetaConfig, WrMetaHandle } from './interfaces';
@@ -51,6 +51,7 @@ export class WrMeta {
   private readonly meta = inject(Meta);
   private readonly doc = inject(DOCUMENT);
   private readonly defaults = inject(WR_META_DEFAULTS);
+  private readonly injector = inject(Injector);
 
   /** Stack of meta layers. Bottom = defaults, top = currently applied. */
   private readonly stack = signal<readonly WrMetaConfig[]>([this.defaults]);
@@ -87,6 +88,65 @@ export class WrMeta {
     const target = config;
     return {
       pop: () => {
+        this.stack.update(stack => {
+          const idx = stack.lastIndexOf(target);
+          if (idx <= 0) return stack;
+          return [...stack.slice(0, idx), ...stack.slice(idx + 1)];
+        });
+        this.apply();
+      },
+    };
+  }
+
+  /**
+   * Reactive layer. Runs `factory` inside an effect and re-applies the
+   * resolved metadata whenever any signal it reads changes — so a title
+   * (or any field) built from {@link WrI18n}'s `t()` updates live on
+   * locale switch, with no manual re-`set()`.
+   *
+   * Returns a handle whose `.pop()` removes the layer and stops the effect.
+   * Safe to call outside an injection context.
+   *
+   * @example Locale-aware title
+   * ```ts
+   * const meta = inject(WrMeta);
+   * const i18n = inject(WrI18n);
+   *
+   * // `i18n.t(...)` tracks the active locale, so the title re-renders
+   * // every time `i18n.use(...)` switches languages.
+   * meta.bind(() => ({
+   *   title: i18n.t('home.title'),
+   *   description: i18n.t('home.description'),
+   * }));
+   * ```
+   */
+  bind(factory: () => WrMetaConfig): WrMetaHandle {
+    let current: WrMetaConfig | null = null;
+
+    const ref = effect(
+      () => {
+        const next = factory();
+        // Recompute is reactive; the stack write + DOM apply are not, so
+        // the effect only re-runs on `factory`'s own dependencies.
+        untracked(() => {
+          this.stack.update(stack => {
+            if (current === null) return [...stack, next];
+            const idx = stack.lastIndexOf(current);
+            return idx < 0 ? [...stack, next] : [...stack.slice(0, idx), next, ...stack.slice(idx + 1)];
+          });
+          current = next;
+          this.apply();
+        });
+      },
+      { injector: this.injector }
+    );
+
+    return {
+      pop: () => {
+        ref.destroy();
+        if (current === null) return;
+        const target = current;
+        current = null;
         this.stack.update(stack => {
           const idx = stack.lastIndexOf(target);
           if (idx <= 0) return stack;

--- a/projects/showcase/app/services/meta/meta.html
+++ b/projects/showcase/app/services/meta/meta.html
@@ -35,6 +35,31 @@
   </ngwr-doc-section>
 
   <ngwr-doc-section
+    title="Reactive title (i18n)"
+    description="`bind()` runs its factory inside an effect — read `WrI18n.t()` (or any signal) and the `<head>` re-renders on every locale switch, with no manual re-`set()`."
+  >
+    <ngwr-doc-code [code]="snippets.reactive" language="angular-ts" />
+    <ngwr-doc-snippet code="">
+      <div style="display: flex; flex-wrap: wrap; gap: 0.625rem; align-items: center">
+        <wr-btn (click)="toggleReactiveTitle()">
+          {{ reactiveBound() ? 'Unbind title' : 'Bind title to i18n' }}
+        </wr-btn>
+        <wr-btn color="light" [disabled]="!reactiveBound()" (click)="toggleLocale()">
+          Switch locale (current: {{ i18n.locale() }})
+        </wr-btn>
+      </div>
+      <small style="display: block; margin-top: 0.625rem; color: var(--wr-color-medium)">
+        @if (reactiveBound()) {
+          The browser tab title now tracks <code>app.title</code> — switch the locale and watch it change between “ngwr
+          i18n demo” and “Демо ngwr i18n”.
+        } @else {
+          Bind the title, then switch locale — the document title updates without re-setting it.
+        }
+      </small>
+    </ngwr-doc-snippet>
+  </ngwr-doc-section>
+
+  <ngwr-doc-section
     title="Why ngwr provides this"
     description="Angular's `Title` and `Meta` are low-level setters — every app rebuilds the same canonical-URL / OpenGraph / Twitter-card plumbing on top. `WrMeta` is that layer, with a title template and per-route overrides."
   />

--- a/projects/showcase/app/services/meta/meta.ts
+++ b/projects/showcase/app/services/meta/meta.ts
@@ -1,6 +1,8 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 
-import { WrMeta } from 'ngwr/meta';
+import { WrButton } from 'ngwr/button';
+import { WrI18n } from 'ngwr/i18n';
+import { WrMeta, type WrMetaHandle } from 'ngwr/meta';
 
 import {
   DocApiComponent,
@@ -14,10 +16,14 @@ import {
 @Component({
   selector: 'ngwr-svc-meta-page',
   templateUrl: './meta.html',
-  imports: [DocPageComponent, DocSectionComponent, DocSnippetComponent, DocCodeComponent, DocApiComponent],
+  imports: [WrButton, DocPageComponent, DocSectionComponent, DocSnippetComponent, DocCodeComponent, DocApiComponent],
 })
 export default class MetaServicePageComponent {
   private readonly metaService = inject(WrMeta);
+  protected readonly i18n = inject(WrI18n);
+
+  private reactiveHandle: WrMetaHandle | null = null;
+  protected readonly reactiveBound = signal(false);
 
   protected pushMeta(): void {
     const handle = this.metaService.push({
@@ -25,6 +31,22 @@ export default class MetaServicePageComponent {
       description: 'Open devtools → Elements → <head> to see the changes.',
     });
     setTimeout(() => handle.pop(), 4000);
+  }
+
+  /** Bind a locale-aware title — `i18n.t()` re-applies on every locale switch. */
+  protected toggleReactiveTitle(): void {
+    if (this.reactiveHandle) {
+      this.reactiveHandle.pop();
+      this.reactiveHandle = null;
+      this.reactiveBound.set(false);
+      return;
+    }
+    this.reactiveHandle = this.metaService.bind(() => ({ title: this.i18n.t('app.title') }));
+    this.reactiveBound.set(true);
+  }
+
+  protected toggleLocale(): void {
+    this.i18n.use(this.i18n.locale() === 'en' ? 'ru' : 'en');
   }
 
   protected readonly snippets = {
@@ -53,6 +75,19 @@ ngOnInit() {
 <div [wrMeta]="{ title: 'Pricing', description: 'Plans for every team.' }">
   …
 </div>`,
+    reactive: `private readonly meta = inject(WrMeta);
+private readonly i18n = inject(WrI18n);
+
+ngOnInit() {
+  // \`i18n.t(...)\` tracks the active locale, so the document title
+  // re-renders automatically whenever the language changes — no
+  // manual re-set on \`NavigationEnd\` or a locale subscription.
+  const handle = this.meta.bind(() => ({
+    title: this.i18n.t('home.title'),
+    description: this.i18n.t('home.description'),
+  }));
+  this.destroyRef.onDestroy(() => handle.pop());
+}`,
   };
 
   protected readonly api: readonly DocApiRow[] = [
@@ -66,6 +101,13 @@ ngOnInit() {
       name: 'push(config)',
       description: 'Push a new layer. Returns `{ pop }` — call `.pop()` to remove.',
       type: '(config: WrMetaConfig) => WrMetaHandle',
+      default: '—',
+    },
+    {
+      name: 'bind(factory)',
+      description:
+        'Reactive layer — re-applies whenever a signal read inside `factory` changes (e.g. `WrI18n.t()` on locale switch). Returns `{ pop }`.',
+      type: '(factory: () => WrMetaConfig) => WrMetaHandle',
       default: '—',
     },
     { name: 'pop()', description: 'Pop the most recently pushed layer.', type: '() => void', default: '—' },


### PR DESCRIPTION
Adds `WrMeta.bind(factory)` — runs the factory in an effect and re-applies `<head>` whenever a signal it reads changes. With `WrI18n.t()` the document title re-renders on every locale switch (no manual re-`set()`). Returns a `{ pop }` handle. Showcase demo + API row. Verified live: title flips en/ru on locale toggle.