### PR TITLE
chore: bump pnpm to 11.8.0 and node engines floor to 24.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ for overlay, portal, and a11y primitives.
 | `date-fns` _(optional)_     | `^3.0.0 \|\| ^4.0.0` |
 | `luxon` _(optional)_        | `^3.0.0`             |
 
-Node ≥ 24.15.0 (or 26+). pnpm ≥ 11.5. TypeScript ≥ 6.0.
+Node ≥ 24.16.0 (or 26+). pnpm ≥ 11.8. TypeScript ≥ 6.0.
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "commit-msg": "npx --no-install commitlint --edit $1"
   },
   "engines": {
-    "node": "^24.15.0 || >=26.0.0",
-    "pnpm": "^11.5.0"
+    "node": "^24.16.0 || >=26.0.0",
+    "pnpm": "^11.8.0"
   },
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.8.0",
   "dependencies": {
     "@angular/cdk": "^22.0.2",
     "@angular/common": "^22.0.2",


### PR DESCRIPTION
- **pnpm**: `packageManager` from 11.5.2 to 11.8.0, `engines.pnpm` floor from `^11.5.0` to `^11.8.0`.
- **node**: `engines.node` floor from `^24.15.0` to `^24.16.0`
- README requirements updated to match.