### PR TITLE
fix(release): insert new changelog section under the heading

### DIFF
--- a/scripts/lib/changelog/regenerate.ts
+++ b/scripts/lib/changelog/regenerate.ts
@@ -29,6 +29,11 @@ export async function regenerateChangelog(): Promise<void> {
     section += chunk;
   }
 
+  // Insert the new section *under* the top-level "# Changelog" heading
+  // rather than above it — a blind prepend re-strands the H1 between the
+  // newest and previous release sections every time.
   const existing = readFileSync(CHANGELOG_PATH, 'utf8');
-  writeFileSync(CHANGELOG_PATH, `${section}${existing}`);
+  const body = existing.replace(/^# Changelog\s*\n+/, '');
+  const block = section.replace(/\n*$/, '\n\n');
+  writeFileSync(CHANGELOG_PATH, `# Changelog\n\n${block}${body}`);
 }


### PR DESCRIPTION
`regenerateChangelog` prepended each new version section above the whole file, which re-stranded the `# Changelog` H1 between the newest and previous release sections every release (hand-fixed for 7.0.0 and 7.1.0). Now it inserts the section *under* the H1.

Verified by simulating a prepend against the current CHANGELOG: H1 stays at the top (single), sections properly separated, release-body extraction stays clean.