### PR TITLE
ci: gate publish and deploy on lint before shipping

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # Gate the deploy on lint + build — nothing ships unless both pass.
+      - run: pnpm lint
+
       - run: pnpm build:showcase
 
       - uses: easingthemes/ssh-deploy@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,6 +64,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # Gate the publish on lint + build — nothing ships unless both pass.
+      - run: pnpm lint
+
       - run: pnpm build:lib
 
       - name: Generate release body


### PR DESCRIPTION
Adds `pnpm lint` before the build step in both `publish.yml` and `deploy.yml`, so neither ships unless lint + build pass. Closes the gap where a lint failure wouldn't block a release/deploy.

Both already ran their build (`build:lib` / `build:showcase`) before shipping, so build was gated; lint was the only missing check. 