### PR TITLE
feat(showcase): mobile-responsive shell

### DIFF
--- a/projects/showcase/app/_core/components/doc-page/doc-page.scss
+++ b/projects/showcase/app/_core/components/doc-page/doc-page.scss
@@ -1,3 +1,5 @@
+@use 'lib/styles/breakpoints' as bp;
+
 :host {
   display: flex;
   flex-direction: column;
@@ -5,6 +7,13 @@
   padding: 1.5rem;
   max-width: 64rem;
   margin: 0 auto;
+
+  // Reclaim the side gutters on phones — 1.5rem each edge is ~13% of a
+  // 375px viewport. Vertical rhythm tightens a touch to match.
+  @include bp.media-down(sm) {
+    gap: 2rem;
+    padding: 1.25rem 1rem;
+  }
 }
 
 .header {

--- a/projects/showcase/app/_core/components/doc-playground/doc-playground.scss
+++ b/projects/showcase/app/_core/components/doc-playground/doc-playground.scss
@@ -3,6 +3,8 @@
 // novel bits are the floating Replay button and the "Customize" panel
 // of dark chip controls beneath.
 
+@use 'lib/styles/breakpoints' as bp;
+
 :host {
   display: block;
 }
@@ -22,6 +24,10 @@
   justify-content: flex-start;
   gap: 0.75rem;
   padding: 1.5rem;
+
+  @include bp.media-down(sm) {
+    padding: 1rem;
+  }
 
   // Divider lives only when there's source underneath.
   &:has(+ .code) {

--- a/projects/showcase/app/_layout/layout.html
+++ b/projects/showcase/app/_layout/layout.html
@@ -1,7 +1,28 @@
 <div class="ngwr-layout">
-  <ngwr-sidebar />
+  @if (isDesktop()) {
+    <ngwr-sidebar />
+  }
 
   <main class="ngwr-layout__content">
+    @if (!isDesktop()) {
+      <div class="ngwr-layout__mobile-bar">
+        <button
+          type="button"
+          class="ngwr-layout__menu-btn"
+          aria-label="Open section navigation"
+          [attr.aria-expanded]="sidebarOpen()"
+          (click)="sidebarOpen.set(true)"
+        >
+          <wr-icon name="menu" size="16" />
+          <span>Menu</span>
+        </button>
+      </div>
+
+      <wr-drawer [(open)]="sidebarOpen" position="left" width="min(18rem, 85vw)">
+        <ngwr-sidebar />
+      </wr-drawer>
+    }
+
     <router-outlet />
     <ngwr-footer compact />
   </main>

--- a/projects/showcase/app/_layout/layout.scss
+++ b/projects/showcase/app/_layout/layout.scss
@@ -35,4 +35,49 @@
       grid-column: 1;
     }
   }
+
+  // Slim sticky bar that opens the section nav drawer below `md`.
+  &__mobile-bar {
+    position: sticky;
+    top: var(--ngwr-header-height, 4rem);
+    z-index: 10;
+
+    padding: 0.5rem var(--wr-grid-gutter);
+
+    background: rgba(var(--wr-color-white-rgb), 0.85);
+    border-bottom: 1px solid var(--wr-color-light-lighter);
+    backdrop-filter: blur(8px);
+  }
+
+  &__menu-btn {
+    appearance: none;
+    cursor: pointer;
+    font: inherit;
+
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+
+    color: var(--wr-color-dark);
+    font-size: 0.875rem;
+    font-weight: 600;
+    line-height: 1rem;
+
+    background: transparent;
+    border: 1px solid var(--wr-color-light-lighter);
+    border-radius: 0.375rem;
+    padding: 0.375rem 0.625rem;
+
+    transition: var(--wr-transition-base);
+
+    &:hover {
+      color: var(--wr-color-primary);
+      background: rgba(var(--wr-color-primary-rgb), 0.1);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--wr-color-primary);
+      outline-offset: 2px;
+    }
+  }
 }

--- a/projects/showcase/app/_layout/layout.ts
+++ b/projects/showcase/app/_layout/layout.ts
@@ -1,5 +1,14 @@
-import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { Component, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { NavigationEnd, Router, RouterOutlet } from '@angular/router';
+
+import { filter } from 'rxjs';
+
+import { Menu } from 'lucide';
+import { WrDrawer } from 'ngwr/drawer';
+import { provideWrIcons, WrIcon } from 'ngwr/icon';
+import { lucideIcons } from 'ngwr/icon/adapters/lucide';
+import { WrMedia } from 'ngwr/media';
 
 import { Footer } from './footer/footer';
 import { Sidebar } from './sidebar/sidebar';
@@ -8,6 +17,22 @@ import { Sidebar } from './sidebar/sidebar';
   selector: 'ngwr-layout',
   templateUrl: './layout.html',
   styleUrl: './layout.scss',
-  imports: [RouterOutlet, Sidebar, Footer],
+  imports: [RouterOutlet, Sidebar, Footer, WrDrawer, WrIcon],
+  providers: [provideWrIcons(lucideIcons({ menu: Menu }))],
 })
-export default class Layout {}
+export default class Layout {
+  /** Below `md` the sidebar moves into an off-canvas drawer. */
+  protected readonly isDesktop = inject(WrMedia).matches('md');
+
+  protected readonly sidebarOpen = signal(false);
+
+  constructor() {
+    // Close the drawer once the picked page has loaded.
+    inject(Router)
+      .events.pipe(
+        filter(e => e instanceof NavigationEnd),
+        takeUntilDestroyed()
+      )
+      .subscribe(() => this.sidebarOpen.set(false));
+  }
+}

--- a/projects/showcase/app/_layout/sidebar/sidebar.scss
+++ b/projects/showcase/app/_layout/sidebar/sidebar.scss
@@ -3,40 +3,28 @@
 :host {
   --ngwr-sidebar-width: 14rem;
 
-  position: sticky;
+  // Below `md` the host renders inside the layout's wr-drawer and just
+  // fills the panel; the sticky-column chrome is desktop-only.
+  display: block;
+  width: 100%;
+  height: 100%;
   overflow-y: auto;
-  height: calc(100vh - var(--ngwr-header-height, 4rem));
-  top: var(--ngwr-header-height, 4rem);
-
-  align-self: start;
-  width: var(--ngwr-sidebar-width);
-
-  border-right: 1px solid var(--wr-color-light-lighter);
 
   padding: 1.5rem 0.75rem 2rem;
+
+  @include bp.media-up(md) {
+    position: sticky;
+    height: calc(100vh - var(--ngwr-header-height, 4rem));
+    top: var(--ngwr-header-height, 4rem);
+
+    align-self: start;
+    width: var(--ngwr-sidebar-width);
+
+    border-right: 1px solid var(--wr-color-light-lighter);
+  }
 }
 
 .ngwr-sidebar {
-  @include bp.media-down(md) {
-    position: fixed;
-    top: var(--ngwr-header-height, 4rem);
-    left: 0;
-    z-index: 15;
-    width: min(20rem, 100vw);
-    max-width: 100vw;
-    height: calc(100vh - var(--ngwr-header-height, 4rem));
-    background: var(--wr-color-white);
-    border-right: 1px solid var(--wr-color-light);
-    transform: translateX(-100%);
-    transition: transform var(--wr-transition-base);
-  }
-
-  &--opened {
-    @include bp.media-down(md) {
-      transform: translateX(0);
-    }
-  }
-
   &__inner {
     display: flex;
     flex-direction: column;

--- a/projects/showcase/app/_root/header/header.html
+++ b/projects/showcase/app/_root/header/header.html
@@ -46,5 +46,39 @@
         <wr-icon [name]="action.icon" />
       </a>
     }
+
+    <button
+      type="button"
+      class="ngwr-header__action ngwr-header__action--burger"
+      aria-label="Open navigation"
+      [attr.aria-expanded]="menuOpen()"
+      (click)="menuOpen.set(true)"
+    >
+      <wr-icon name="menu" />
+    </button>
   </div>
 </header>
+
+<wr-drawer [(open)]="menuOpen" position="right" width="min(17rem, 85vw)">
+  <nav class="ngwr-header__sheet" aria-label="Primary, mobile">
+    @for (link of nav; track $index) {
+      <a
+        class="ngwr-header__sheet-link"
+        [routerLink]="link.url"
+        routerLinkActive="ngwr-header__sheet-link--active"
+        (click)="menuOpen.set(false)"
+      >
+        {{ link.label }}
+      </a>
+    }
+
+    <div class="ngwr-header__sheet-divider" role="presentation"></div>
+
+    @for (action of actions; track action.url) {
+      <a class="ngwr-header__sheet-link" [href]="action.url" target="_blank" rel="noopener noreferrer">
+        <wr-icon [name]="action.icon" />
+        {{ action.label }}
+      </a>
+    }
+  </nav>
+</wr-drawer>

--- a/projects/showcase/app/_root/header/header.html
+++ b/projects/showcase/app/_root/header/header.html
@@ -47,19 +47,19 @@
       </a>
     }
 
-    <button
-      type="button"
-      class="ngwr-header__action ngwr-header__action--burger"
-      aria-label="Open navigation"
-      [attr.aria-expanded]="menuOpen()"
-      (click)="menuOpen.set(true)"
-    >
-      <wr-icon name="menu" />
-    </button>
+    <wr-burger class="ngwr-header__burger" [(open)]="menuOpen" label="Toggle navigation" />
   </div>
 </header>
 
 <wr-drawer [(open)]="menuOpen" position="right" width="min(17rem, 85vw)">
+  <!-- The close toggle lives inside the drawer so it sits in the overlay's
+       top layer, visually above the menu — the page header (and its burger)
+       are painted under it. Same `menuOpen` signal, so it morphs to a close
+       mark and shuts the menu. -->
+  <div class="ngwr-header__sheet-top">
+    <wr-burger [(open)]="menuOpen" label="Close navigation" />
+  </div>
+
   <nav class="ngwr-header__sheet" aria-label="Primary, mobile">
     @for (link of nav; track $index) {
       <a

--- a/projects/showcase/app/_root/header/header.scss
+++ b/projects/showcase/app/_root/header/header.scss
@@ -196,8 +196,7 @@
       }
     }
 
-    &--theme,
-    &--burger {
+    &--theme {
       // Strip the default <button> chrome so it matches the anchor
       // siblings (GitHub / npm).
       appearance: none;
@@ -216,14 +215,30 @@
         outline-offset: 2px;
       }
     }
+  }
 
-    &--burger {
-      display: none;
+  // The animated menu toggle replaces the inline nav below `xl`. It opens
+  // the drawer; the matching close toggle lives inside the drawer panel
+  // (`&__sheet-top`) so it renders in the overlay's top layer, above the
+  // menu. Both share the `menuOpen` signal.
+  &__burger {
+    --wr-burger-size: 2.25rem;
 
-      @include bp.media-down(xl) {
-        display: inline-flex;
-      }
+    display: none;
+
+    @include bp.media-down(xl) {
+      display: inline-flex;
     }
+  }
+
+  // Close toggle row, pinned to the top-right of the drawer panel so it
+  // lands roughly where the header burger was.
+  &__sheet-top {
+    display: flex;
+    justify-content: flex-end;
+    padding: 0.5rem 0.75rem 0;
+
+    --wr-burger-size: 2.25rem;
   }
 
   // Mobile nav sheet (inside the burger drawer).
@@ -231,7 +246,7 @@
     display: flex;
     flex-direction: column;
     gap: 0.125rem;
-    padding: 1rem 0.75rem;
+    padding: 0.5rem 0.75rem 1rem;
 
     &-link {
       display: flex;

--- a/projects/showcase/app/_root/header/header.scss
+++ b/projects/showcase/app/_root/header/header.scss
@@ -72,6 +72,11 @@
     justify-content: flex-start;
     gap: 0.5rem;
 
+    // Twelve links don't fit under ~1200px — the burger sheet takes over.
+    @include bp.media-down(xl) {
+      display: none;
+    }
+
     &-link {
       --ngwr-header-nav-link-color: var(--wr-color-dark);
       --ngwr-header-nav-link-bg: transparent;
@@ -191,7 +196,8 @@
       }
     }
 
-    &--theme {
+    &--theme,
+    &--burger {
       // Strip the default <button> chrome so it matches the anchor
       // siblings (GitHub / npm).
       appearance: none;
@@ -209,6 +215,57 @@
         outline: 2px solid var(--wr-color-primary);
         outline-offset: 2px;
       }
+    }
+
+    &--burger {
+      display: none;
+
+      @include bp.media-down(xl) {
+        display: inline-flex;
+      }
+    }
+  }
+
+  // Mobile nav sheet (inside the burger drawer).
+  &__sheet {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    padding: 1rem 0.75rem;
+
+    &-link {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+
+      color: var(--wr-color-dark);
+      font-size: 0.9375rem;
+      font-weight: 600;
+      line-height: 1.25rem;
+
+      border-radius: 0.375rem;
+      padding: 0.625rem 0.75rem;
+
+      transition: var(--wr-transition-base);
+
+      --wr-icon-size: 1rem;
+
+      &:hover {
+        color: var(--wr-color-primary);
+        background: rgba(var(--wr-color-primary-rgb), 0.1);
+      }
+
+      &--active,
+      &--active:hover {
+        color: var(--wr-color-medium);
+        background: rgba(var(--wr-color-light-rgb), 0.3);
+      }
+    }
+
+    &-divider {
+      height: 1px;
+      margin: 0.5rem 0.75rem;
+      background: var(--wr-color-light-lighter);
     }
   }
 

--- a/projects/showcase/app/_root/header/header.ts
+++ b/projects/showcase/app/_root/header/header.ts
@@ -2,7 +2,8 @@ import { isPlatformBrowser } from '@angular/common';
 import { Component, DestroyRef, ElementRef, PLATFORM_ID, inject, signal } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 
-import { Menu, Moon, Sun } from 'lucide';
+import { Moon, Sun } from 'lucide';
+import { WrBurger } from 'ngwr/burger';
 import { WrDrawer } from 'ngwr/drawer';
 import { provideWrIcons, WrIcon } from 'ngwr/icon';
 import { lucideIcons } from 'ngwr/icon/adapters/lucide';
@@ -27,8 +28,8 @@ interface ActionLink {
   selector: 'ngwr-header',
   templateUrl: './header.html',
   styleUrl: './header.scss',
-  imports: [RouterLink, RouterLinkActive, WrDrawer, WrIcon],
-  providers: [provideWrIcons([...BRAND_ICONS, ...lucideIcons({ menu: Menu, moon: Moon, sun: Sun })])],
+  imports: [RouterLink, RouterLinkActive, WrBurger, WrDrawer, WrIcon],
+  providers: [provideWrIcons([...BRAND_ICONS, ...lucideIcons({ moon: Moon, sun: Sun })])],
 })
 export class Header {
   protected readonly theme = inject(WrTheme);

--- a/projects/showcase/app/_root/header/header.ts
+++ b/projects/showcase/app/_root/header/header.ts
@@ -1,8 +1,9 @@
 import { isPlatformBrowser } from '@angular/common';
-import { Component, DestroyRef, ElementRef, PLATFORM_ID, inject } from '@angular/core';
+import { Component, DestroyRef, ElementRef, PLATFORM_ID, inject, signal } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 
-import { Moon, Sun } from 'lucide';
+import { Menu, Moon, Sun } from 'lucide';
+import { WrDrawer } from 'ngwr/drawer';
 import { provideWrIcons, WrIcon } from 'ngwr/icon';
 import { lucideIcons } from 'ngwr/icon/adapters/lucide';
 import { WrTheme } from 'ngwr/theme';
@@ -26,8 +27,8 @@ interface ActionLink {
   selector: 'ngwr-header',
   templateUrl: './header.html',
   styleUrl: './header.scss',
-  imports: [RouterLink, RouterLinkActive, WrIcon],
-  providers: [provideWrIcons([...BRAND_ICONS, ...lucideIcons({ moon: Moon, sun: Sun })])],
+  imports: [RouterLink, RouterLinkActive, WrDrawer, WrIcon],
+  providers: [provideWrIcons([...BRAND_ICONS, ...lucideIcons({ menu: Menu, moon: Moon, sun: Sun })])],
 })
 export class Header {
   protected readonly theme = inject(WrTheme);
@@ -51,6 +52,9 @@ export class Header {
     { url: 'https://github.com/thekhegay/ngwr', icon: 'github', modifier: 'github', label: 'GitHub' },
     { url: 'https://www.npmjs.com/package/ngwr', icon: 'npm', modifier: 'npm', label: 'npm' },
   ];
+
+  /** Mobile nav sheet — the inline nav collapses to a burger below `xl`. */
+  protected readonly menuOpen = signal(false);
 
   protected onToggleTheme(): void {
     this.theme.toggle();

--- a/projects/showcase/app/home/home.html
+++ b/projects/showcase/app/home/home.html
@@ -15,8 +15,8 @@
             [from]="{ opacity: 0, y: 36 }"
             [to]="{ opacity: 1, y: 0 }"
           />
-          <span class="ngwr-home-hero__title-angular"><wr-icon name="logo-angular" />&nbsp;Angular</span
-          >&nbsp;applications.
+          <span class="ngwr-home-hero__title-angular"><wr-icon name="logo-angular" />&nbsp;Angular</span>
+          applications.
         </h1>
 
         <div class="ngwr-home-hero__cta">

--- a/projects/showcase/app/home/home.scss
+++ b/projects/showcase/app/home/home.scss
@@ -104,16 +104,18 @@
 
   &__title {
     color: var(--wr-color-dark);
-    font-size: 3rem;
+    // Scales down to ~2.1rem on a 375px viewport so the headline wraps
+    // inside the container instead of clipping at the edges.
+    font-size: clamp(2rem, 4.27vw + 1rem, 3rem);
     font-weight: 700;
-    line-height: 3.25rem;
+    line-height: 1.1;
     letter-spacing: -1px;
     margin: 0;
 
     wr-icon {
-      --wr-icon-size: 2.75rem;
+      --wr-icon-size: 0.92em;
       color: var(--wr-color-secondary);
-      vertical-align: -0.375rem;
+      vertical-align: -0.125em;
     }
   }
 


### PR DESCRIPTION
- **Docs sidebar → off-canvas drawer below `md`**, opened from a sticky "Menu" bar; auto-closes on navigation. Built on `wr-drawer` + `WrMedia`.
- **Header nav → burger below `xl`** — the 12-link nav collapses into a `wr-burger` that opens a right-side drawer; a matching close-burger sits in the drawer's top layer (the "burger over menu" pattern).
- **Hero un-clipped** — `clamp()` title scale + removed the `&nbsp;` that glued "applications." into one unbreakable unit.
- **Tighter doc-page + playground gutters** on small viewports; controls already stack.