### PR TITLE
feat(overlay): responsive bottom-sheet overlays, applied to dialog

### DIFF
--- a/projects/lib/dialog/dialog.ts
+++ b/projects/lib/dialog/dialog.ts
@@ -11,7 +11,7 @@ import { ComponentPortal, type ComponentType } from '@angular/cdk/portal';
 import { isPlatformBrowser } from '@angular/common';
 import { EnvironmentInjector, Service, Injector, PLATFORM_ID, inject } from '@angular/core';
 
-import { WR_OVERLAY } from 'ngwr/overlay';
+import { WR_OVERLAY, WR_RESPONSIVE_OVERLAYS, wrPresentAsSheet } from 'ngwr/overlay';
 
 import { WrDialogRef } from './dialog-ref';
 import type { WrDialogOptions } from './interfaces';
@@ -49,6 +49,7 @@ export class WrDialog {
   private readonly parentInjector = inject(EnvironmentInjector);
   private readonly focusTrapFactory = inject(ConfigurableFocusTrapFactory);
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+  private readonly responsiveConfig = inject(WR_RESPONSIVE_OVERLAYS);
 
   open<C, R = unknown, D = unknown>(component: ComponentType<C>, options: WrDialogOptions<D> = {}): WrDialogRef<C, R> {
     const panelClasses: string[] = [DEFAULT_PANEL_CLASS];
@@ -59,14 +60,20 @@ export class WrDialog {
       for (const cls of extra) panelClasses.push(cls);
     }
 
+    // On small viewports (when opted in) present as a slide-up sheet pinned
+    // to the bottom edge, full-width, instead of a centred modal.
+    const asSheet = wrPresentAsSheet(options.responsive, this.responsiveConfig);
+    if (asSheet) panelClasses.push('wr-overlay-sheet');
+
+    const position = this.overlay.position().global().centerHorizontally();
     const overlayRef: OverlayRef = this.overlay.create({
-      positionStrategy: this.overlay.position().global().centerHorizontally().centerVertically(),
+      positionStrategy: asSheet ? position.bottom('0') : position.centerVertically(),
       scrollStrategy: this.scrollStrategies.block(),
       hasBackdrop: true,
       backdropClass: DEFAULT_BACKDROP_CLASS,
       panelClass: panelClasses,
-      width: options.width,
-      maxWidth: options.maxWidth,
+      width: asSheet ? '100%' : options.width,
+      maxWidth: asSheet ? '100%' : options.maxWidth,
     });
 
     const dialogRef = new WrDialogRef<C, R>(overlayRef);

--- a/projects/lib/dialog/interfaces/dialog-options.ts
+++ b/projects/lib/dialog/interfaces/dialog-options.ts
@@ -21,4 +21,10 @@ export interface WrDialogOptions<D = unknown> {
   readonly maxWidth?: string;
   /** Extra CSS class(es) added to the panel. */
   readonly panelClass?: string | readonly string[];
+  /**
+   * Present as a full-width bottom-sheet on small viewports instead of a
+   * centred modal. `undefined` follows the app-wide
+   * `provideWrResponsiveOverlays()` setting; `true`/`false` overrides it.
+   */
+  readonly responsive?: boolean;
 }

--- a/projects/lib/dialog/styles/_index.scss
+++ b/projects/lib/dialog/styles/_index.scss
@@ -122,3 +122,27 @@
     transform: scale(1);
   }
 }
+
+// Responsive bottom-sheet presentation. Added to a component's overlay
+// panel (alongside `wr-dialog-panel`, `wr-select-overlay`, …) when
+// `provideWrResponsiveOverlays()` / a `responsive` option pins the overlay
+// to the bottom edge on small viewports. `!important` so it wins over each
+// component's own panel sizing regardless of stylesheet order.
+.wr-overlay-sheet {
+  width: 100% !important;
+  min-width: 0 !important;
+  max-width: 100% !important;
+  max-height: 90vh !important;
+  border-radius: var(--wr-border-radius-lg) var(--wr-border-radius-lg) 0 0 !important;
+  padding-bottom: env(safe-area-inset-bottom);
+  animation: wr-overlay-sheet-up var(--wr-overlay-duration, 0.2s) var(--wr-overlay-ease, ease-out) !important;
+}
+
+@keyframes wr-overlay-sheet-up {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}

--- a/projects/lib/overlay/provide-wr-responsive-overlays.ts
+++ b/projects/lib/overlay/provide-wr-responsive-overlays.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/thekhegay/ngwr/blob/main/LICENSE
+ */
+
+import { type EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
+
+import { WR_RESPONSIVE_OVERLAYS, type WrResponsiveOverlaysConfig } from './tokens/wr-responsive-overlays.token';
+
+/**
+ * Opt every NGWR overlay into responsive presentation — on viewports at or
+ * below `breakpoint`, dialogs / selects / dropdowns and friends slide up as
+ * a full-width bottom-sheet instead of a floating panel. Built on the same
+ * overlay plumbing, so focus-trap, backdrop and scroll-blocking carry over.
+ *
+ * Individual components can still opt out (or in) per instance via their
+ * `responsive` option.
+ *
+ * @example
+ * ```ts
+ * bootstrapApplication(AppComponent, {
+ *   providers: [provideWrOverlay(), provideWrResponsiveOverlays()],
+ * });
+ *
+ * // Custom breakpoint:
+ * provideWrResponsiveOverlays({ breakpoint: 768 });
+ * ```
+ */
+export function provideWrResponsiveOverlays(config?: Partial<WrResponsiveOverlaysConfig>): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    { provide: WR_RESPONSIVE_OVERLAYS, useValue: { breakpoint: config?.breakpoint ?? 640 } },
+  ]);
+}

--- a/projects/lib/overlay/public-api.ts
+++ b/projects/lib/overlay/public-api.ts
@@ -1,3 +1,4 @@
 export { WrOverlayContainer } from './wr-overlay-container';
 export { provideWrOverlay } from './provide-wr-overlay';
-export { WR_OVERLAY, WR_OVERLAY_CONTAINER } from './tokens';
+export { provideWrResponsiveOverlays } from './provide-wr-responsive-overlays';
+export { WR_OVERLAY, WR_OVERLAY_CONTAINER, WR_RESPONSIVE_OVERLAYS, wrPresentAsSheet } from './tokens';

--- a/projects/lib/overlay/tokens/index.ts
+++ b/projects/lib/overlay/tokens/index.ts
@@ -1,2 +1,7 @@
 export { WR_OVERLAY } from './wr-overlay.token';
 export { WR_OVERLAY_CONTAINER } from './wr-overlay-container.token';
+export {
+  WR_RESPONSIVE_OVERLAYS,
+  wrPresentAsSheet,
+  type WrResponsiveOverlaysConfig,
+} from './wr-responsive-overlays.token';

--- a/projects/lib/overlay/tokens/wr-responsive-overlays.token.ts
+++ b/projects/lib/overlay/tokens/wr-responsive-overlays.token.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/thekhegay/ngwr/blob/main/LICENSE
+ */
+
+import { InjectionToken } from '@angular/core';
+
+/** Configuration for responsive (bottom-sheet) overlay presentation. */
+interface WrResponsiveOverlaysConfig {
+  /**
+   * Viewport width (CSS px) at or below which overlays present as a
+   * bottom-sheet instead of a floating panel. @default 640
+   */
+  readonly breakpoint: number;
+}
+
+/**
+ * When set, overlay services (dialog, select, dropdown, …) present as a
+ * slide-up bottom-sheet on viewports at or below `breakpoint`. `null`
+ * (the default) keeps every overlay floating. Configure via
+ * {@link provideWrResponsiveOverlays}; override per call with a
+ * component's `responsive` option.
+ *
+ * @internal
+ */
+const WR_RESPONSIVE_OVERLAYS = new InjectionToken<WrResponsiveOverlaysConfig | null>('WR_RESPONSIVE_OVERLAYS', {
+  factory: () => null,
+});
+
+/**
+ * Decide whether an overlay should present as a bottom-sheet for the
+ * current viewport.
+ *
+ * - `responsive === true` — sheet on small viewports regardless of config.
+ * - `responsive === false` — never a sheet.
+ * - `responsive === undefined` — follow the global config (sheet when
+ *   {@link provideWrResponsiveOverlays} is configured).
+ *
+ * SSR-safe: returns `false` when there's no `window`.
+ *
+ * @internal
+ */
+function wrPresentAsSheet(responsive: boolean | undefined, config: WrResponsiveOverlaysConfig | null): boolean {
+  const enabled = responsive ?? config !== null;
+  if (!enabled || typeof window === 'undefined') return false;
+  return window.innerWidth <= (config?.breakpoint ?? 640);
+}
+
+export { WR_RESPONSIVE_OVERLAYS, wrPresentAsSheet };
+export type { WrResponsiveOverlaysConfig };

--- a/projects/showcase/app/components/dialog/dialog.html
+++ b/projects/showcase/app/components/dialog/dialog.html
@@ -20,6 +20,16 @@
     </ngwr-doc-snippet>
   </ngwr-doc-section>
 
+  <ngwr-doc-section
+    title="Responsive (bottom-sheet)"
+    description="With `responsive: true` — or app-wide via `provideWrResponsiveOverlays()` — the dialog slides up as a full-width bottom-sheet on small viewports and stays a centred modal on larger ones. Open this on a phone (or narrow the window) to see it dock to the bottom."
+  >
+    <ngwr-doc-code [code]="snippets.responsive" language="angular-ts" />
+    <ngwr-doc-snippet code="dialog.open(ConfirmComponent, { responsive: true })">
+      <wr-btn (click)="openConfirm(true)">Open responsive dialog</wr-btn>
+    </ngwr-doc-snippet>
+  </ngwr-doc-section>
+
   <ngwr-doc-section title="Service API">
     <ngwr-doc-api [rows]="api" />
   </ngwr-doc-section>

--- a/projects/showcase/app/components/dialog/dialog.ts
+++ b/projects/showcase/app/components/dialog/dialog.ts
@@ -43,6 +43,12 @@ const ok = await ref.awaitClose(); // result from <wr-btn wrDialogClose value>`,
   <wr-btn wrDialogClose>Cancel</wr-btn>
   <wr-btn color="danger" [wrDialogClose]="true">Delete</wr-btn>
 </div>`,
+    responsive: `// Per dialog — slides up as a bottom-sheet on small screens.
+dialog.open(ConfirmComponent, { responsive: true });
+
+// Or app-wide, for every overlay:
+provideWrResponsiveOverlays();          // default breakpoint 640px
+provideWrResponsiveOverlays({ breakpoint: 768 });`,
   };
 
   protected readonly api: readonly DocApiRow[] = [
@@ -71,10 +77,11 @@ const ok = await ref.awaitClose(); // result from <wr-btn wrDialogClose value>`,
     },
   ];
 
-  protected async openConfirm(): Promise<void> {
+  protected async openConfirm(responsive = false): Promise<void> {
     const ref = this.dialog.open<ConfirmDialogComponent, boolean, ConfirmData>(ConfirmDialogComponent, {
       data: { title: 'Delete item?', message: 'This action cannot be undone.' },
       width: '24rem',
+      responsive,
     });
     const result = await ref.awaitClose();
     this.lastResult.set(result === true ? 'Confirmed' : 'Cancelled');


### PR DESCRIPTION
**Foundation (`ngwr/overlay`):**
- `provideWrResponsiveOverlays({ breakpoint? })` — opt every overlay into bottom-sheet presentation on small viewports (default ≤ 640px).
- `WR_RESPONSIVE_OVERLAYS` token + `wrPresentAsSheet()` helper (SSR-safe) for components to share.
- Shared `.wr-overlay-sheet` panel styles: full-width, bottom-pinned, top-rounded, slide-up, safe-area-aware.

**Dialog:** new `responsive?` option on `WrDialog.open()`. When on (per-call or via the provider) the dialog slides up as a full-width bottom-sheet on phones and stays a centred modal otherwise.