### PR TITLE
feat(select): responsive bottom-sheet panel on small viewports

### DIFF
--- a/projects/lib/dialog/styles/_index.scss
+++ b/projects/lib/dialog/styles/_index.scss
@@ -1,4 +1,5 @@
 @use '../../theme/styles' as theme;
+@use '../../overlay/styles'; // shared .wr-overlay-sheet for responsive mode
 
 // CDK Overlay base styles are usually loaded once by the consumer.
 // We re-emit the minimal `cdk-overlay-*` rules so a standalone `@use
@@ -123,26 +124,3 @@
   }
 }
 
-// Responsive bottom-sheet presentation. Added to a component's overlay
-// panel (alongside `wr-dialog-panel`, `wr-select-overlay`, …) when
-// `provideWrResponsiveOverlays()` / a `responsive` option pins the overlay
-// to the bottom edge on small viewports. `!important` so it wins over each
-// component's own panel sizing regardless of stylesheet order.
-.wr-overlay-sheet {
-  width: 100% !important;
-  min-width: 0 !important;
-  max-width: 100% !important;
-  max-height: 90vh !important;
-  border-radius: var(--wr-border-radius-lg) var(--wr-border-radius-lg) 0 0 !important;
-  padding-bottom: env(safe-area-inset-bottom);
-  animation: wr-overlay-sheet-up var(--wr-overlay-duration, 0.2s) var(--wr-overlay-ease, ease-out) !important;
-}
-
-@keyframes wr-overlay-sheet-up {
-  from {
-    transform: translateY(100%);
-  }
-  to {
-    transform: translateY(0);
-  }
-}

--- a/projects/lib/overlay/styles/_index.scss
+++ b/projects/lib/overlay/styles/_index.scss
@@ -1,0 +1,31 @@
+// Shared presentation styles for responsive (bottom-sheet) overlays.
+// Added to a component's overlay panel (`wr-dialog-panel`,
+// `wr-select-overlay`, …) when `provideWrResponsiveOverlays()` or a
+// component's `responsive` option pins the overlay to the bottom edge on
+// small viewports. `!important` so it wins over each component's own panel
+// sizing regardless of stylesheet order.
+
+.wr-overlay-sheet {
+  width: 100% !important;
+  min-width: 0 !important;
+  max-width: 100% !important;
+  max-height: 90vh !important;
+  border-radius: var(--wr-border-radius-lg) var(--wr-border-radius-lg) 0 0 !important;
+  padding-bottom: env(safe-area-inset-bottom);
+  animation: wr-overlay-sheet-up var(--wr-overlay-duration, 0.2s) var(--wr-overlay-ease, ease-out) !important;
+}
+
+// Dim + blur behind a sheet — for overlays that otherwise have no backdrop.
+.wr-overlay-backdrop {
+  background: rgba(var(--wr-color-backdrop-rgb), 0.45);
+  backdrop-filter: blur(2px);
+}
+
+@keyframes wr-overlay-sheet-up {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}

--- a/projects/lib/package.json
+++ b/projects/lib/package.json
@@ -2,7 +2,7 @@
   "name": "ngwr",
   "version": "7.1.0",
   "license": "MIT",
-  "description": "NGWR – Angular UI components library",
+  "description": "NGWR \u2013 Angular UI components library",
   "author": "Roman Khegay <rk@garuna.dev> (https://garuna.dev)",
   "keywords": [
     "ngwr",
@@ -246,6 +246,9 @@
     },
     "./meter-group": {
       "sass": "./meter-group/styles/_index.scss"
+    },
+    "./overlay": {
+      "sass": "./overlay/styles/_index.scss"
     },
     "./page-header": {
       "sass": "./page-header/styles/_index.scss"

--- a/projects/lib/select/select.ts
+++ b/projects/lib/select/select.ts
@@ -5,7 +5,7 @@
  * found in the LICENSE file at https://github.com/thekhegay/ngwr/blob/main/LICENSE
  */
 
-import { coerceBooleanProperty } from '@angular/cdk/coercion';
+import { type BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
 import { type OverlayRef, ScrollStrategyOptions } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
 import {
@@ -29,7 +29,7 @@ import { type ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { type Observable, debounceTime, finalize, from, isObservable, of, switchMap } from 'rxjs';
 
 import { useI18nFormatter, useI18nText } from 'ngwr/i18n';
-import { WR_OVERLAY } from 'ngwr/overlay';
+import { WR_OVERLAY, WR_RESPONSIVE_OVERLAYS, wrPresentAsSheet } from 'ngwr/overlay';
 import { noop } from 'ngwr/utils';
 
 import type { WrSelectMode, WrSelectSearchLoader, WrSelectTagValidator } from './interfaces';
@@ -119,6 +119,16 @@ export class WrSelect implements ControlValueAccessor, WrSelectContext {
 
   /** Pill-shaped corners on the trigger. @default false */
   readonly rounded = input(false, { transform: coerceBooleanProperty });
+
+  /**
+   * Present the option panel as a full-width bottom-sheet on small
+   * viewports instead of an anchored dropdown. `undefined` follows the
+   * app-wide `provideWrResponsiveOverlays()` setting; `true`/`false`
+   * overrides it. @default undefined
+   */
+  readonly responsive = input<boolean | undefined, BooleanInput>(undefined, {
+    transform: (v: BooleanInput): boolean | undefined => (v == null ? undefined : coerceBooleanProperty(v)),
+  });
 
   /**
    * Behavior mode. `<wr-select>` is the unified combobox primitive —
@@ -435,6 +445,7 @@ export class WrSelect implements ControlValueAccessor, WrSelectContext {
 
   private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
   private readonly overlay = inject(WR_OVERLAY);
+  private readonly responsiveConfig = inject(WR_RESPONSIVE_OVERLAYS);
   private readonly vcr = inject(ViewContainerRef);
   private readonly scrollStrategies = inject(ScrollStrategyOptions);
   private readonly destroyRef = inject(DestroyRef);
@@ -770,24 +781,39 @@ export class WrSelect implements ControlValueAccessor, WrSelectContext {
   private openOverlay(): void {
     if (this.overlayRef) return;
 
-    const positionStrategy = this.overlay
-      .position()
-      .flexibleConnectedTo(this.host)
-      .withPositions([
-        { originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top' },
-        { originX: 'start', originY: 'top', overlayX: 'start', overlayY: 'bottom' },
-      ])
-      .withPush(true);
+    // On small viewports (when opted in) detach from the trigger and present
+    // the panel as a full-width slide-up sheet pinned to the bottom edge.
+    const asSheet = wrPresentAsSheet(this.responsive(), this.responsiveConfig);
+
+    const positionStrategy = asSheet
+      ? this.overlay.position().global().centerHorizontally().bottom('0')
+      : this.overlay
+          .position()
+          .flexibleConnectedTo(this.host)
+          .withPositions([
+            { originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top' },
+            { originX: 'start', originY: 'top', overlayX: 'start', overlayY: 'bottom' },
+          ])
+          .withPush(true);
 
     this.overlayRef = this.overlay.create({
       positionStrategy,
-      scrollStrategy: this.scrollStrategies.reposition(),
-      width: this.host.nativeElement.getBoundingClientRect().width,
-      panelClass: 'wr-select-overlay',
+      scrollStrategy: asSheet ? this.scrollStrategies.block() : this.scrollStrategies.reposition(),
+      width: asSheet ? '100%' : this.host.nativeElement.getBoundingClientRect().width,
+      hasBackdrop: asSheet,
+      backdropClass: asSheet ? 'wr-select-backdrop' : undefined,
+      panelClass: asSheet ? ['wr-select-overlay', 'wr-overlay-sheet'] : 'wr-select-overlay',
     });
 
     const portal = new TemplatePortal(this.panelTpl(), this.vcr);
     this.overlayRef.attach(portal);
+
+    if (asSheet) {
+      this.overlayRef
+        .backdropClick()
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe(() => this.open.set(false));
+    }
 
     this.overlayRef
       .outsidePointerEvents()

--- a/projects/lib/select/styles/_index.scss
+++ b/projects/lib/select/styles/_index.scss
@@ -1,4 +1,5 @@
 @use '../../theme/styles' as theme;
+@use '../../overlay/styles'; // shared .wr-overlay-sheet / .wr-overlay-backdrop for responsive mode
 
 .wr-select {
   --wr-select-color: var(--wr-color-dark);

--- a/projects/lib/styles.scss
+++ b/projects/lib/styles.scss
@@ -74,6 +74,7 @@
 @forward './marquee/styles';
 @forward './mention/styles';
 @forward './meter-group/styles';
+@forward './overlay/styles';
 @forward './page-header/styles';
 @forward './pagination/styles';
 @forward './popconfirm/styles';

--- a/projects/showcase/app/components/select/select.html
+++ b/projects/showcase/app/components/select/select.html
@@ -21,6 +21,23 @@
     </ngwr-doc-snippet>
   </ngwr-doc-section>
 
+  <ngwr-doc-section
+    title="Responsive (bottom-sheet)"
+    description="With `responsive` — or app-wide via `provideWrResponsiveOverlays()` — the option panel detaches from the trigger and slides up as a full-width bottom-sheet on small viewports, with a backdrop. Open this on a phone (or narrow the window below 640px) to see it dock to the bottom."
+  >
+    <ngwr-doc-snippet code='<wr-select responsive placeholder="Pick a size">…</wr-select>'>
+      <div style="display: flex; flex-direction: column; gap: 0.5rem">
+        <wr-select responsive placeholder="Pick a size" [(ngModel)]="respSize">
+          <wr-option value="sm">Small</wr-option>
+          <wr-option value="md">Medium</wr-option>
+          <wr-option value="lg">Large</wr-option>
+          <wr-option value="xl">Extra large</wr-option>
+        </wr-select>
+        <span style="color: var(--wr-color-medium); font-size: 0.875rem">Value: {{ respSize() ?? 'none' }}</span>
+      </div>
+    </ngwr-doc-snippet>
+  </ngwr-doc-section>
+
   <ngwr-doc-section title="Groups" description="Use <wr-option-group> to label sections of related options.">
     <ngwr-doc-snippet [code]="snippets.groups">
       <div style="display: flex; flex-direction: column; gap: 0.5rem">

--- a/projects/showcase/app/components/select/select.ts
+++ b/projects/showcase/app/components/select/select.ts
@@ -31,6 +31,7 @@ import {
 })
 export default class SelectComponent {
   protected readonly size = signal<string | null>(null);
+  protected readonly respSize = signal<string | null>(null);
   protected readonly framework = signal<string | null>('angular');
   protected readonly tags = signal<readonly string[]>(['typescript', 'angular']);
   protected readonly manyTags = signal<readonly string[]>(['typescript', 'angular', 'rxjs', 'signals']);


### PR DESCRIPTION
- New `responsive` input. On small viewports (per the input or app-wide `provideWrResponsiveOverlays()`) the option panel **detaches from the trigger** and slides up as a full-width bottom-sheet with a backdrop; on larger viewports it stays an anchored dropdown.
- **Extracted the shared `.wr-overlay-sheet` styles** out of the dialog entry into a new `ngwr/overlay` styles entry (now that a second component needs them), plus a shared `.wr-overlay-backdrop`. Dialog + select both `@use` it; the umbrella `@use 'ngwr'` and per-component `@use 'ngwr/dialog'` / `'ngwr/select'` all pick it up.