### PR TITLE
feat(popover): responsive bottom-sheet panel in popover mode

### DIFF
--- a/projects/lib/popover/popover.ts
+++ b/projects/lib/popover/popover.ts
@@ -5,6 +5,7 @@
  * found in the LICENSE file at https://github.com/thekhegay/ngwr/blob/main/LICENSE
  */
 
+import { type BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
 import { type OverlayRef, ScrollStrategyOptions } from '@angular/cdk/overlay';
 import { ComponentPortal, TemplatePortal } from '@angular/cdk/portal';
 import type { TemplateRef } from '@angular/core';
@@ -22,7 +23,7 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
-import { WR_OVERLAY } from 'ngwr/overlay';
+import { WR_OVERLAY, WR_RESPONSIVE_OVERLAYS, wrPresentAsSheet } from 'ngwr/overlay';
 import { numAttr } from 'ngwr/utils';
 
 import { WR_POPOVER_POSITIONS, type WrPopoverPosition } from './interfaces';
@@ -108,6 +109,16 @@ export class WrPopover {
   /** Tooltip only — delay before hiding, in ms. @default 60 */
   readonly hideDelay = input(60, { transform: numAttr(60) });
 
+  /**
+   * Popover mode only — present the panel as a full-width bottom-sheet on
+   * small viewports instead of an anchored panel. `undefined` follows the
+   * app-wide `provideWrResponsiveOverlays()` setting; `true`/`false`
+   * overrides it. Tooltips never become sheets. @default undefined
+   */
+  readonly responsive = input<boolean | undefined, BooleanInput>(undefined, {
+    transform: (v: BooleanInput): boolean | undefined => (v == null ? undefined : coerceBooleanProperty(v)),
+  });
+
   /** Fires after the panel opens. */
   readonly opened = output<void>();
 
@@ -116,6 +127,7 @@ export class WrPopover {
 
   private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
   private readonly overlay = inject(WR_OVERLAY);
+  private readonly responsiveConfig = inject(WR_RESPONSIVE_OVERLAYS);
   private readonly vcr = inject(ViewContainerRef);
   private readonly scrollStrategies = inject(ScrollStrategyOptions);
   private readonly destroyRef = inject(DestroyRef);
@@ -254,21 +266,40 @@ export class WrPopover {
     const tooltip = this.isTooltip();
     const position = this.resolvedPosition();
 
-    const positionStrategy = this.overlay
-      .position()
-      .flexibleConnectedTo(this.host)
-      .withPositions(WR_POPOVER_POSITIONS[position])
-      .withPush(true);
+    // Sheet presentation is popover-only — tooltips are transient labels and
+    // never dock to the bottom. On small viewports (when opted in) detach
+    // from the trigger and slide the panel up from the bottom edge.
+    const asSheet = !tooltip && wrPresentAsSheet(this.responsive(), this.responsiveConfig);
+
+    const positionStrategy = asSheet
+      ? this.overlay.position().global().centerHorizontally().bottom('0')
+      : this.overlay
+          .position()
+          .flexibleConnectedTo(this.host)
+          .withPositions(WR_POPOVER_POSITIONS[position])
+          .withPush(true);
 
     const overlayClass = tooltip
       ? ['wr-tooltip-overlay', `wr-tooltip-overlay--${position}`]
-      : ['wr-popover-overlay', `wr-popover-overlay--${position}`];
+      : asSheet
+        ? ['wr-popover-overlay', 'wr-overlay-sheet']
+        : ['wr-popover-overlay', `wr-popover-overlay--${position}`];
 
     this.overlayRef = this.overlay.create({
       positionStrategy,
-      scrollStrategy: this.scrollStrategies.reposition(),
+      scrollStrategy: asSheet ? this.scrollStrategies.block() : this.scrollStrategies.reposition(),
+      width: asSheet ? '100%' : undefined,
+      hasBackdrop: asSheet,
+      backdropClass: asSheet ? 'wr-overlay-backdrop' : undefined,
       panelClass: overlayClass,
     });
+
+    if (asSheet) {
+      this.overlayRef
+        .backdropClick()
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe(() => this.isOpen.set(false));
+    }
 
     const content = this.content();
 

--- a/projects/lib/popover/styles/_index.scss
+++ b/projects/lib/popover/styles/_index.scss
@@ -1,4 +1,5 @@
 @use '../../theme/styles' as theme;
+@use '../../overlay/styles'; // shared .wr-overlay-sheet / .wr-overlay-backdrop for responsive mode
 
 .wr-popover-overlay {
   > * {

--- a/projects/showcase/app/components/popover/popover.html
+++ b/projects/showcase/app/components/popover/popover.html
@@ -23,6 +23,24 @@
     </ngwr-doc-snippet>
   </ngwr-doc-section>
 
+  <ngwr-doc-section
+    title="Responsive (bottom-sheet)"
+    description="Popover mode only — with `responsive` (or app-wide via `provideWrResponsiveOverlays()`) the panel slides up as a full-width bottom-sheet with a backdrop on small viewports. Tooltips never become sheets. Open this on a phone (or narrow the window below 640px)."
+  >
+    <ngwr-doc-snippet code='<wr-btn [wrPopover]="tpl" responsive>Details</wr-btn>'>
+      <wr-btn color="primary" [wrPopover]="respInfo" responsive>Details</wr-btn>
+
+      <ng-template #respInfo>
+        <div style="padding: 1rem; max-width: 18rem">
+          <p style="margin: 0 0 0.375rem; font-weight: 600">About NGWR</p>
+          <p style="margin: 0; color: var(--wr-color-medium); font-size: 0.8125rem">
+            On a phone this panel docks to the bottom as a sheet; on desktop it stays anchored to the trigger.
+          </p>
+        </div>
+      </ng-template>
+    </ngwr-doc-snippet>
+  </ngwr-doc-section>
+
   <ngwr-doc-section title="Hover trigger">
     <ngwr-doc-snippet [code]="snippets.hover">
       <wr-btn [wrPopover]="card" trigger="hover">Hover me</wr-btn>


### PR DESCRIPTION
New `responsive` input. On small viewports the popover panel detaches from the trigger and slides up as a full-width bottom-sheet with a backdrop; anchored otherwise. **Popover mode only** — tooltips (`mode="tooltip"`) are transient labels and never dock to the bottom (guarded by `!tooltip`). Reuses the shared `.wr-overlay-sheet` / `.wr-overlay-backdrop` styles.