### PR TITLE
feat(command-palette): full-screen presentation on small viewports

### DIFF
--- a/projects/lib/command-palette/command-palette.html
+++ b/projects/lib/command-palette/command-palette.html
@@ -1,5 +1,11 @@
 @if (open()) {
-  <div class="wr-command-palette" role="dialog" aria-modal="true" aria-label="Command palette">
+  <div
+    class="wr-command-palette"
+    [class.wr-command-palette--sheet]="presentAsSheet()"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Command palette"
+  >
     <!-- Backdrop captures clicks to close. Not focusable — keyboard users use
          Esc on the panel below. -->
 

--- a/projects/lib/command-palette/command-palette.ts
+++ b/projects/lib/command-palette/command-palette.ts
@@ -6,7 +6,7 @@
  */
 
 import { type ConfigurableFocusTrap, ConfigurableFocusTrapFactory } from '@angular/cdk/a11y';
-import { coerceBooleanProperty } from '@angular/cdk/coercion';
+import { type BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
 import { isPlatformBrowser } from '@angular/common';
 import {
   Component,
@@ -28,6 +28,7 @@ import {
 import { WrHotkey, type WrHotkeyHandle, type WrHotkeySpec } from 'ngwr/hotkey';
 import { useI18nText } from 'ngwr/i18n';
 import { WrIcon } from 'ngwr/icon';
+import { WR_RESPONSIVE_OVERLAYS, wrPresentAsSheet } from 'ngwr/overlay';
 
 import type { WrCommandItem } from './interfaces';
 
@@ -107,11 +108,25 @@ export class WrCommandPalette {
   /** Auto-close on `(picked)`. Set false to keep open. @default true */
   readonly closeOnPick = input(true, { transform: coerceBooleanProperty });
 
+  /**
+   * Present the palette full-screen on small viewports instead of a centred
+   * modal. `undefined` follows the app-wide `provideWrResponsiveOverlays()`
+   * setting; `true`/`false` overrides it. The palette docks to the top (it
+   * auto-focuses its input, so the on-screen keyboard stays clear).
+   * @default undefined
+   */
+  readonly responsive = input<boolean | undefined, BooleanInput>(undefined, {
+    transform: (v: BooleanInput): boolean | undefined => (v == null ? undefined : coerceBooleanProperty(v)),
+  });
+
   /** Fires when the user commits an item (Enter / click). */
   readonly picked = output<WrCommandItem>();
 
   protected readonly query = signal('');
   protected readonly activeIndex = signal(0);
+
+  /** Whether the current opening is presented full-screen. Decided on open. */
+  protected readonly presentAsSheet = signal(false);
   protected readonly inputEl = viewChild<ElementRef<HTMLInputElement>>('input');
   protected readonly panelEl = viewChild<ElementRef<HTMLElement>>('panel');
 
@@ -130,6 +145,7 @@ export class WrCommandPalette {
   });
 
   private readonly hotkeys = inject(WrHotkey);
+  private readonly responsiveConfig = inject(WR_RESPONSIVE_OVERLAYS);
   private readonly destroyRef = inject(DestroyRef);
   private readonly focusTrapFactory = inject(ConfigurableFocusTrapFactory);
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
@@ -159,6 +175,7 @@ export class WrCommandPalette {
       if (!this.open()) return;
       this.query.set('');
       this.activeIndex.set(0);
+      this.presentAsSheet.set(wrPresentAsSheet(this.responsive(), this.responsiveConfig));
     });
 
     // Focus trap + restore.

--- a/projects/lib/command-palette/styles/_index.scss
+++ b/projects/lib/command-palette/styles/_index.scss
@@ -167,6 +167,31 @@
   }
 }
 
+// Full-screen presentation on small viewports — opt in per-instance with
+// `responsive` or app-wide via `provideWrResponsiveOverlays()`. The palette
+// auto-focuses its input, so it fills the screen from the top edge rather than
+// docking to the bottom (a bottom-sheet would sit under the on-screen
+// keyboard). The list flexes to fill the remaining height.
+.wr-command-palette--sheet {
+  padding: 0;
+
+  .wr-command-palette__panel {
+    max-width: none;
+    height: 100%;
+    max-height: 100%;
+    display: flex;
+    flex-direction: column;
+    border: 0;
+    border-radius: 0;
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+
+  .wr-command-palette__body {
+    flex: 1 1 auto;
+    max-height: none;
+  }
+}
+
 @keyframes wr-cmd-fade {
   from {
     opacity: 0;

--- a/projects/showcase/app/components/command-palette/command-palette.html
+++ b/projects/showcase/app/components/command-palette/command-palette.html
@@ -35,6 +35,16 @@
   </ngwr-doc-section>
 
   <ngwr-doc-section
+    title="Responsive (full-screen)"
+    description="With `responsive` — or app-wide via `provideWrResponsiveOverlays()` — the palette fills the screen from the top edge on small viewports instead of a centred modal (it auto-focuses its input, so it stays clear of the on-screen keyboard). Open this on a phone (or narrow the window below 640px)."
+  >
+    <ngwr-doc-snippet code='<wr-command-palette responsive [items]="items" [(open)]="open" />'>
+      <button wr-btn type="button" color="primary" (click)="respOpen.set(true)">Open palette</button>
+      <wr-command-palette responsive [items]="items" [(open)]="respOpen" [trigger]="null" (picked)="onPicked($event)" />
+    </ngwr-doc-snippet>
+  </ngwr-doc-section>
+
+  <ngwr-doc-section
     title="Programmatic control"
     description="Set `[(open)]` and pass `[trigger]` of `null` to disable the auto-bound hotkey when you want to open it from your own UI."
   >

--- a/projects/showcase/app/components/command-palette/command-palette.ts
+++ b/projects/showcase/app/components/command-palette/command-palette.ts
@@ -27,6 +27,7 @@ import {
 })
 export default class CommandPalettePage {
   protected readonly open = signal(false);
+  protected readonly respOpen = signal(false);
   protected readonly last = signal<string | null>(null);
 
   protected readonly items: readonly WrCommandItem[] = [


### PR DESCRIPTION
New `responsive` input. On small viewports the palette fills the screen from the top edge instead of a centred modal; unchanged otherwise. Unlike the bottom-sheet overlays, the palette **auto-focuses its search input**, so a bottom-sheet would sit under the on-screen keyboard — it docks to the **top** and goes full-screen (edge-to-edge, list flexes to fill). Follows the same opt-in semantics (`responsive` input / app-wide `provideWrResponsiveOverlays()`).

Note: command-palette isn't CDK-overlay-based (it renders inline, CSS-positioned), so it uses its own `--sheet` modifier rather than the shared `.wr-overlay-sheet` class. The sheet-vs-centred decision is made at open time via `wrPresentAsSheet`, consistent with the CDK components.