### PR TITLE
feat(theme): touch-target mixin and apply to overlay close buttons

### DIFF
--- a/projects/lib/alert/styles/_index.scss
+++ b/projects/lib/alert/styles/_index.scss
@@ -80,6 +80,8 @@ $alert-colors: (
 
     --wr-icon-size: 1rem;
 
+    @include theme.touch-target; // ~20px glyph -> 44px tap area on touch
+
     &:hover {
       color: var(--wr-alert-title);
       background: rgba(var(--wr-color-light-rgb), 0.4);

--- a/projects/lib/lightbox/styles/_index.scss
+++ b/projects/lib/lightbox/styles/_index.scss
@@ -100,6 +100,8 @@
       background 0.15s ease,
       transform 0.15s ease;
 
+    @include theme.touch-target($positioned: true); // 36px -> 44px tap area on touch
+
     &:hover {
       background: rgba(255, 255, 255, 0.2);
     }

--- a/projects/lib/theme/styles/_mixins.scss
+++ b/projects/lib/theme/styles/_mixins.scss
@@ -55,3 +55,50 @@
     border-radius: calc(#{$br} * 1.85);
   }
 }
+
+/// Expand a small control's touch hit area to a comfortable minimum on
+/// coarse (touch) pointers, without changing how it looks. Lays an
+/// invisible, centred `::after` over the control that's at least `$size`
+/// square; taps on the slack still land on the host. Fine-pointer
+/// (mouse / trackpad) layouts are left exactly as-is, so dense desktop
+/// UIs keep their tight targets.
+///
+/// Use on small icon-only controls — close (×) buttons, chip removes,
+/// tree / cascader toggles — where the visible glyph is well under the
+/// ~44px comfortable tap size. Skip controls that are already tall
+/// enough, and avoid it on tightly-packed rows where a 44px slack would
+/// overlap a neighbouring target.
+///
+/// The pseudo is absolutely positioned, so the host must be a containing
+/// block. For the common static control the mixin sets `position:
+/// relative` for you; pass `$positioned: true` when the host is already
+/// `absolute` / `fixed` / `relative` so the mixin doesn't downgrade its
+/// positioning under the media query.
+///
+/// @param {Length} $size [44px] - Minimum hit-area edge (Apple HIG).
+/// @param {Bool} $positioned [false] - Set true if the host already
+///   establishes a positioning context (skips `position: relative`).
+///
+/// @example scss
+///   .wr-alert__close {
+///     @include touch-target;
+///   }
+@mixin touch-target($size: 44px, $positioned: false) {
+  @media (pointer: coarse) {
+    @if not $positioned {
+      position: relative;
+    }
+
+    &::after {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 100%;
+      height: 100%;
+      min-width: $size;
+      min-height: $size;
+      transform: translate(-50%, -50%);
+    }
+  }
+}


### PR DESCRIPTION
**`@include theme.touch-target($size: 44px, $positioned: false)`** — lays an invisible, centred `::after` over a small control so its tap area is at least 44x44 (Apple HIG), without changing how it looks. Gated entirely behind `@media (pointer: coarse)`, so mouse/trackpad (fine-pointer) layouts are **provably untouched** — dense desktop UIs keep their tight targets. `$positioned: true` skips the `position: relative` it would otherwise set, for hosts that are already `absolute`/`fixed` (e.g. the lightbox close).

Applied to:
- **alert** close (~20px glyph) -> 44px tap area on touch
- **lightbox** close (36px) -> 44px on touch (`$positioned: true`, keeps its absolute top-right placement)

Verified via CSSOM that both rules ship correctly inside the coarse-pointer media query, and that the positioned path emits **no** `position: relative` (would otherwise break the lightbox's absolute placement). Fine-pointer preview confirms the rules stay dormant on desktop. Lint + lib + showcase green.

**Deliberately scoped to isolated controls.** The remaining small controls sit in dense rows/clusters where a 44px slack would overlap a neighbouring target — **select** chip-removes, **tree**/**cascader** disclosure toggles, **toast** action rows (copy + dismiss), **window** traffic-light chrome. Giving those a comfortable tap size means real spacing changes that affect desktop layout, so they need a separate call rather than the invisible-slack technique. Follow-up PR will propose how to handle them (touch-only spacing vs leave as-is).