### PR TITLE
feat: comfortable touch targets for dense content controls

### DIFF
--- a/projects/lib/cascader/styles/_index.scss
+++ b/projects/lib/cascader/styles/_index.scss
@@ -172,3 +172,19 @@
     color: var(--wr-color-medium);
   }
 }
+
+// Touch pointers: grow the clear button and make the column option rows ~44px
+// tall so each is a comfortable tap target. Fine pointers keep the compact
+// desktop sizing above.
+@media (pointer: coarse) {
+  .wr-cascader__clear {
+    --wr-icon-size: 1.125rem;
+    width: 2rem;
+    height: 2rem;
+  }
+
+  .wr-cascader-panel .wr-cascader__opt {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+  }
+}

--- a/projects/lib/select/styles/_index.scss
+++ b/projects/lib/select/styles/_index.scss
@@ -322,3 +322,29 @@
     padding-top: 0.25rem;
   }
 }
+
+// Touch pointers: grow the chip removes / clear button and open up the chip
+// rows so each is a comfortable tap target without overlapping its neighbour.
+// The removes reach ~32px in a ~44px-tall chip; fine pointers keep the
+// compact desktop sizing above.
+@media (pointer: coarse) {
+  .wr-select__chips {
+    gap: 0.375rem;
+  }
+
+  .wr-select__chip {
+    gap: 0.375rem;
+    padding: 0.375rem 0.5rem 0.375rem 0.75rem;
+  }
+
+  .wr-select__chip-remove,
+  .wr-select__clear {
+    --wr-icon-size: 1.125rem;
+    width: 2rem;
+    height: 2rem;
+  }
+
+  .wr-select__clear {
+    margin-right: 0;
+  }
+}

--- a/projects/lib/toast/styles/_index.scss
+++ b/projects/lib/toast/styles/_index.scss
@@ -261,3 +261,28 @@ $toast-colors: (
   order: 99;
   align-self: stretch;
 }
+
+// Touch pointers: grow the per-toast action buttons (copy / dismiss) to ~32px
+// with a wider gap so the pair no longer sits 2px apart, and give the
+// dismiss-all bar a taller hit area. Fine pointers keep the compact desktop
+// sizing above.
+@media (pointer: coarse) {
+  .wr-toast__actions {
+    gap: 0.25rem;
+  }
+
+  .wr-toast__action {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    padding: 0;
+    --wr-icon-size: 1.125rem;
+  }
+
+  .wr-toast-host__close-all {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+  }
+}

--- a/projects/lib/tree/styles/_index.scss
+++ b/projects/lib/tree/styles/_index.scss
@@ -269,3 +269,18 @@
   max-height: var(--wr-tree-panel-max-height, 18rem);
   overflow-y: auto;
 }
+
+// Touch pointers: taller rows (~44px) and a larger expand/collapse toggle so
+// both the row and its toggle are comfortable tap targets. Fine pointers keep
+// the compact desktop rows above.
+@media (pointer: coarse) {
+  .wr-tree__row {
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+
+  .wr-tree__toggle {
+    width: 1.75rem;
+    height: 1.75rem;
+  }
+}


### PR DESCRIPTION
| Control | Touch treatment |
|---|---|
| **select** chips | chip-removes / clear -> 32px, chips -> ~44px tall, wider gaps |
| **tree** rows | rows -> ~44px, expand/collapse toggle -> 28px |
| **cascader** | clear -> 32px, column option rows -> ~44px |
| **toast** actions | copy / dismiss -> 32px with a wider gap (were 2px apart); dismiss-all bar taller |

**Verification.** Since the desktop preview is a fine-pointer device, the coarse rules are dormant there — so I verified the touch layout by temporarily swapping the media condition to always-on and screenshotting at the touch sizing (select chips: 44px tall, 32px removes, no overlap; tree: 44px rows, 28px toggles, balanced), then reverted. Cascader + toast confirmed via CSSOM that the rules ship correctly inside the coarse media query. Every component re-checked to confirm the rule stays dormant on fine pointers (desktop sizing intact). 