### PR TITLE
feat: honor safe-area insets on fixed surfaces (toast, command-palette, back-top)

### DIFF
--- a/projects/lib/back-top/styles/_index.scss
+++ b/projects/lib/back-top/styles/_index.scss
@@ -2,8 +2,10 @@
 
 .wr-back-top {
   position: fixed;
-  bottom: 1.5rem;
-  right: 1.5rem;
+  // Safe-area: lift the floating button clear of the home indicator / rounded
+  // corner on mobile. env() is 0 without insets, so desktop stays 1.5rem.
+  bottom: calc(1.5rem + env(safe-area-inset-bottom));
+  right: calc(1.5rem + env(safe-area-inset-right));
   z-index: 50;
   opacity: 0;
   pointer-events: none;

--- a/projects/lib/command-palette/styles/_index.scss
+++ b/projects/lib/command-palette/styles/_index.scss
@@ -183,6 +183,9 @@
     flex-direction: column;
     border: 0;
     border-radius: 0;
+    // Top-docked full-screen: clear the notch at the top (search bar) and the
+    // home indicator at the bottom. The panel background still fills both edges.
+    padding-top: env(safe-area-inset-top);
     padding-bottom: env(safe-area-inset-bottom);
   }
 

--- a/projects/lib/toast/styles/_index.scss
+++ b/projects/lib/toast/styles/_index.scss
@@ -20,7 +20,11 @@ $toast-colors: (
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  padding: 1rem;
+  // Safe-area: fold each inset into the matching padding side so toasts clear
+  // notches / the home indicator / rounded corners on mobile, whichever edge
+  // the host is anchored to. env() is 0 without insets, so desktop stays 1rem.
+  padding: calc(1rem + env(safe-area-inset-top)) calc(1rem + env(safe-area-inset-right))
+    calc(1rem + env(safe-area-inset-bottom)) calc(1rem + env(safe-area-inset-left));
   pointer-events: none;
   max-width: 22rem;
   width: 100%;


### PR DESCRIPTION
- **toast host** — folds each inset into the matching padding side (`calc(1rem + env(safe-area-inset-*))`), so toasts clear whichever edge the host is anchored to (top/bottom/start/end) without per-variant rules.
- **command-palette** full-screen — was padding only the bottom; the sheet docks to the **top**, so added `padding-top: env(safe-area-inset-top)` to clear the notch behind the search bar (panel background still fills the edge).
- **back-top** — lifts the floating button by `env(safe-area-inset-bottom/right)` so it clears the home indicator / rounded corner.
- **drawer** (has a `--safe-area` opt-in across all four insets) and the **M2 bottom-sheets** (`.wr-overlay-sheet` pads `safe-area-inset-bottom`).