### PR TITLE
feat: opt-in container-query responsive reflow (descriptions, stepper, page-header)

### DIFF
--- a/projects/lib/descriptions/descriptions.ts
+++ b/projects/lib/descriptions/descriptions.ts
@@ -40,10 +40,19 @@ export class WrDescriptions {
   /** Add visible borders around each row. @default false */
   readonly bordered = input(false, { transform: coerceBooleanProperty });
 
+  /**
+   * Reflow `inline` rows back to a stacked layout when the box itself is
+   * narrow (a container query on its own width, not the viewport — so it
+   * adapts inside a narrow card or side panel). Makes the box fill its
+   * container's width. @default false
+   */
+  readonly responsive = input(false, { transform: coerceBooleanProperty });
+
   protected readonly classes = computed(() => {
     const parts = ['wr-descriptions'];
     if (this.inline()) parts.push('wr-descriptions--inline');
     if (this.bordered()) parts.push('wr-descriptions--bordered');
+    if (this.responsive()) parts.push('wr-descriptions--responsive');
     return parts.join(' ');
   });
 }

--- a/projects/lib/descriptions/styles/_index.scss
+++ b/projects/lib/descriptions/styles/_index.scss
@@ -5,6 +5,16 @@
   font-family: var(--wr-font-family-base);
   color: var(--wr-color-dark);
 
+  // Opt-in (`responsive`): query the box's own width so inline layouts reflow
+  // to stacked inside a narrow card / side panel, regardless of the viewport.
+  // `inline-size` containment drops content-based sizing, so the box fills its
+  // container's width; without this it would collapse to 0 inside a
+  // shrink-to-fit parent (flex / grid / inline-block).
+  &--responsive {
+    container: wr-descriptions / inline-size;
+    width: 100%;
+  }
+
   &__title {
     font-size: var(--wr-text-base);
     font-weight: var(--wr-font-weight-semibold);
@@ -100,5 +110,54 @@
   &--bordered#{&}--inline &__label {
     background: rgba(var(--wr-color-light-rgb), 0.35);
     border-right: 1px solid var(--wr-color-light);
+  }
+}
+
+// When the descriptions box itself is narrow (not the viewport), inline modes
+// reflow back to the stacked single-column layout so label/value pairs stay
+// readable in a narrow card or side panel. Override selectors match the base
+// inline rules' specificity (0-3-0 for bordered) so the cascade picks them up.
+@container wr-descriptions (max-width: 24rem) {
+  .wr-descriptions--inline .wr-descriptions__list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .wr-descriptions--inline .wr-descriptions__row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+  }
+
+  // Bordered + inline reverts to the plain bordered stacked rows: the card
+  // border stays on the list; rows regain their padding + dividers; the label
+  // cells drop their grid background / divider.
+  .wr-descriptions--bordered.wr-descriptions--inline .wr-descriptions__list {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .wr-descriptions--bordered.wr-descriptions--inline .wr-descriptions__row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    padding: 0.625rem 0.875rem;
+  }
+
+  .wr-descriptions--bordered.wr-descriptions--inline .wr-descriptions__row + .wr-descriptions__row {
+    border-top: 1px solid var(--wr-color-light);
+  }
+
+  .wr-descriptions--bordered.wr-descriptions--inline .wr-descriptions__label,
+  .wr-descriptions--bordered.wr-descriptions--inline .wr-descriptions__value {
+    padding: 0;
+    border-top: 0;
+  }
+
+  .wr-descriptions--bordered.wr-descriptions--inline .wr-descriptions__label {
+    background: transparent;
+    border-right: 0;
   }
 }

--- a/projects/lib/page-header/page-header.ts
+++ b/projects/lib/page-header/page-header.ts
@@ -5,6 +5,7 @@
  * found in the LICENSE file at https://github.com/thekhegay/ngwr/blob/main/LICENSE
  */
 
+import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { Component, ViewEncapsulation, input } from '@angular/core';
 
 /**
@@ -34,7 +35,7 @@ import { Component, ViewEncapsulation, input } from '@angular/core';
   selector: 'wr-page-header',
   templateUrl: './page-header.html',
   encapsulation: ViewEncapsulation.None,
-  host: { class: 'wr-page-header' },
+  host: { class: 'wr-page-header', '[class.wr-page-header--responsive]': 'responsive()' },
 })
 export class WrPageHeader {
   /** Primary title shown as an h1. */
@@ -42,4 +43,12 @@ export class WrPageHeader {
 
   /** Secondary line below the title. */
   readonly subtitle = input<string>('');
+
+  /**
+   * Stack the title and actions vertically when the header's own box is too
+   * narrow to sit them side by side (a container query on its own width, not
+   * the viewport — so it adapts inside a narrow column or split pane).
+   * @default false
+   */
+  readonly responsive = input(false, { transform: coerceBooleanProperty });
 }

--- a/projects/lib/page-header/styles/_index.scss
+++ b/projects/lib/page-header/styles/_index.scss
@@ -12,6 +12,13 @@
   border-bottom: 1px solid var(--wr-color-light);
   font-family: var(--wr-font-family-base);
 
+  // Opt-in (`responsive`): query the box's own width so the title + actions row
+  // stacks when the header is too narrow to sit them side by side. The host is
+  // already full-width, so containment is safe here.
+  &--responsive {
+    container: wr-page-header / inline-size;
+  }
+
   &__breadcrumbs {
     font-size: var(--wr-text-sm);
     color: var(--wr-color-medium);
@@ -74,5 +81,14 @@
     &:empty {
       display: none;
     }
+  }
+}
+
+// Responsive headers stack the title above the actions when their own box is
+// too narrow to sit them side by side (regardless of viewport).
+@container wr-page-header (max-width: 32rem) {
+  .wr-page-header--responsive .wr-page-header__main {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }

--- a/projects/lib/stepper/stepper.ts
+++ b/projects/lib/stepper/stepper.ts
@@ -62,11 +62,20 @@ export class WrStepper implements WrStepperContext {
   /** Lock steps after the latest completed one. @default false */
   readonly linear = input(false, { transform: coerceBooleanProperty });
 
+  /**
+   * Drop a horizontal stepper to a vertical layout when its own box is too
+   * narrow for the row (a container query on its own width, not the
+   * viewport — so it adapts inside a narrow column or side panel). No effect
+   * when `orientation` is already `vertical`. @default false
+   */
+  readonly responsive = input(false, { transform: coerceBooleanProperty });
+
   protected readonly steps = contentChildren(WrStep);
 
   protected readonly classes = computed(() => {
     const parts = ['wr-stepper', `wr-stepper--${this.orientation()}`];
     if (this.linear()) parts.push('wr-stepper--linear');
+    if (this.responsive()) parts.push('wr-stepper--responsive');
     return parts.join(' ');
   });
 

--- a/projects/lib/stepper/styles/_index.scss
+++ b/projects/lib/stepper/styles/_index.scss
@@ -14,6 +14,13 @@
   gap: 1rem;
   font-family: var(--wr-font-family-base);
 
+  // Opt-in (`responsive`): query the box's own width so a horizontal stepper
+  // can drop to vertical when its column is too narrow. The host is already
+  // full-width, so containment is safe here.
+  &--responsive {
+    container: wr-stepper / inline-size;
+  }
+
   &__headers {
     list-style: none;
     margin: 0;
@@ -148,6 +155,29 @@
 
   &__body {
     min-height: 0;
+  }
+}
+
+// Responsive horizontal steppers fall back to the vertical layout when their
+// own box is too narrow for the row — mirrors the `--vertical` rules above,
+// scoped to responsive steppers that aren't already vertical.
+@container wr-stepper (max-width: 32rem) {
+  .wr-stepper--responsive:not(.wr-stepper--vertical) .wr-stepper__headers {
+    flex-direction: column;
+  }
+
+  .wr-stepper--responsive:not(.wr-stepper--vertical) .wr-stepper__header {
+    align-items: stretch;
+    flex: 0 0 auto;
+  }
+
+  .wr-stepper--responsive:not(.wr-stepper--vertical) .wr-stepper__connector {
+    width: 1.5px;
+    min-height: 1.25rem;
+    height: auto;
+    margin: 0.25rem 0 0.25rem calc(var(--wr-stepper-indicator-size) / 2);
+    align-self: stretch;
+    flex: 0 0 auto;
   }
 }
 

--- a/projects/showcase/app/components/descriptions/descriptions.html
+++ b/projects/showcase/app/components/descriptions/descriptions.html
@@ -13,4 +13,19 @@
       </wr-descriptions>
     </ngwr-doc-snippet>
   </ngwr-doc-section>
+
+  <ngwr-doc-section
+    title="Narrow container (container query)"
+    description="With `responsive`, inline layouts query their own width, not the viewport — so the same `inline bordered` descriptions reflows to a stacked layout when placed in a narrow container, even on a wide page. The box below is fixed at 280px."
+  >
+    <ngwr-doc-snippet code='<div style="width: 280px"><wr-descriptions responsive inline bordered>…</wr-descriptions></div>'>
+      <div style="width: 280px; max-width: 100%">
+        <wr-descriptions title="Account" responsive inline bordered>
+          <wr-description-item label="Name">Ada Lovelace</wr-description-item>
+          <wr-description-item label="Email">ada@example.com</wr-description-item>
+          <wr-description-item label="Joined">2024-03-12</wr-description-item>
+        </wr-descriptions>
+      </div>
+    </ngwr-doc-snippet>
+  </ngwr-doc-section>
 </ngwr-doc-page>

--- a/projects/showcase/app/components/page-header/page-header.html
+++ b/projects/showcase/app/components/page-header/page-header.html
@@ -15,4 +15,20 @@
       </wr-page-header>
     </ngwr-doc-snippet>
   </ngwr-doc-section>
+
+  <ngwr-doc-section
+    title="Narrow container (container query)"
+    description="With `responsive`, the title + actions row stacks vertically when the header's own box is too narrow — a container query on its own width, not the viewport, so it adapts inside a split pane or sidebar even on a wide page. The box below is fixed at 380px."
+  >
+    <ngwr-doc-snippet code='<div style="width: 380px"><wr-page-header responsive …>…</wr-page-header></div>'>
+      <div style="width: 380px; max-width: 100%">
+        <wr-page-header responsive title="Settings" subtitle="Manage your workspace">
+          <div wrPageHeaderActions>
+            <wr-btn>Invite</wr-btn>
+            <wr-btn color="primary">Save</wr-btn>
+          </div>
+        </wr-page-header>
+      </div>
+    </ngwr-doc-snippet>
+  </ngwr-doc-section>
 </ngwr-doc-page>

--- a/projects/showcase/app/components/stepper/stepper.html
+++ b/projects/showcase/app/components/stepper/stepper.html
@@ -66,6 +66,27 @@
     </ngwr-doc-snippet>
   </ngwr-doc-section>
 
+  <ngwr-doc-section
+    title="Narrow container (container query)"
+    description="With `responsive`, a horizontal stepper queries its own width and drops to the vertical layout when its column is too narrow — even on a wide page. The box below is fixed at 340px."
+  >
+    <ngwr-doc-snippet code='<div style="width: 340px"><wr-stepper responsive>…</wr-stepper></div>'>
+      <div style="width: 340px; max-width: 100%">
+        <wr-stepper responsive [(active)]="narrow">
+          <wr-step label="Account">
+            <p>Tell us about your account.</p>
+          </wr-step>
+          <wr-step label="Profile" description="Optional">
+            <p>Fill in your profile details.</p>
+          </wr-step>
+          <wr-step label="Confirm">
+            <p>Review and submit.</p>
+          </wr-step>
+        </wr-stepper>
+      </div>
+    </ngwr-doc-snippet>
+  </ngwr-doc-section>
+
   <ngwr-doc-section title="API">
     <ngwr-doc-api [rows]="api" />
   </ngwr-doc-section>

--- a/projects/showcase/app/components/stepper/stepper.ts
+++ b/projects/showcase/app/components/stepper/stepper.ts
@@ -28,6 +28,7 @@ export default class StepperPageComponent {
   protected readonly basic = signal(0);
   protected readonly linear = signal(0);
   protected readonly vertical = signal(0);
+  protected readonly narrow = signal(0);
   protected readonly linearStepper = viewChild<WrStepper>('linearStepper');
 
   protected linearNext(): void {
@@ -78,6 +79,12 @@ export class MyComponent {
     {
       name: 'linear',
       description: 'Lock steps after the latest completed one.',
+      type: 'boolean',
+      default: 'false',
+    },
+    {
+      name: 'responsive',
+      description: 'Drop a horizontal stepper to vertical when its own box is too narrow (container query, not viewport).',
       type: 'boolean',
       default: 'false',
     },


### PR DESCRIPTION
| Component | `responsive` reflow (when its box is narrow) |
|---|---|
| **descriptions** | inline 2-col label/value -> stacked single column (< 24rem) |
| **stepper** | horizontal -> vertical layout (< 32rem) |
| **page-header** | title + actions side-by-side -> stacked (< 32rem) |