### PR TITLE
feat: touch-sized handles for slider, splitter, color-picker

### DIFF
--- a/projects/lib/color-picker/styles/_index.scss
+++ b/projects/lib/color-picker/styles/_index.scss
@@ -50,6 +50,13 @@
     cursor: ew-resize;
     touch-action: none;
     box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.06);
+
+    // Coarse pointers: a taller track is easier to drag than the 0.75rem
+    // default. A symmetric 44px hit area would overlap the SV panel above it,
+    // so grow the track itself instead (the thumb stays vertically centred).
+    @media (pointer: coarse) {
+      height: 1.5rem;
+    }
   }
 
   &__slider--hue {

--- a/projects/lib/slider/styles/_index.scss
+++ b/projects/lib/slider/styles/_index.scss
@@ -49,6 +49,9 @@
       transform var(--wr-transition-short),
       box-shadow var(--wr-transition-base);
 
+    // Coarse pointers: invisible 44px tap area so the small thumb is grabbable.
+    @include theme.touch-target($positioned: true);
+
     &:focus-visible {
       outline: none;
       box-shadow: 0 0 0 3px rgba(var(--wr-color-primary-rgb), 0.25);

--- a/projects/lib/splitter/styles/_index.scss
+++ b/projects/lib/splitter/styles/_index.scss
@@ -35,6 +35,9 @@
     outline: 0;
     transition: background var(--wr-transition-base);
 
+    // Coarse pointers: expand the 4px gutter to a 44px tap area.
+    @include theme.touch-target($positioned: true);
+
     &:hover,
     &:focus-visible {
       background: var(--wr-color-primary);


### PR DESCRIPTION
- **slider** — the 16px thumb gets an invisible 44px tap area via the `touch-target` mixin (`$positioned: true`, the thumb is already absolute). The track stays independently clickable.
- **splitter** — the 4px divider gutter (basically ungrabbable on touch) gets the same 44px hit area. The drag already uses pointer-capture, so the enlarged area drives the resize directly.
- **color-picker** — the SV panel is already 160px, but the hue / alpha tracks are 12px and *stacked*, so a symmetric 44px `::after` would overlap the panel above. Instead the tracks grow to 1.5rem (24px) on coarse pointers; the thumb stays vertically centred.
- **knob** — no change: `size` defaults to 120px (min 32px) and the whole dial is the drag target, so it's already a large touch target.