### PR TITLE
feat(context-menu): open on touch long-press

### DIFF
--- a/projects/lib/context-menu/context-menu.ts
+++ b/projects/lib/context-menu/context-menu.ts
@@ -17,9 +17,9 @@ import type { WrContextMenuPanel } from './context-menu-panel';
 
 /**
  * Attach to any element to show a `<wr-context-menu>` at the pointer
- * position when the user right-clicks (or sends a `contextmenu` event by
- * any means — long-press on touch, Shift+F10, etc.). The native browser
- * menu is suppressed for the host element.
+ * position when the user right-clicks, long-presses on touch, or otherwise
+ * sends a `contextmenu` event (Shift+F10, etc.). The native browser menu is
+ * suppressed for the host element.
  *
  * @example
  * ```html
@@ -36,6 +36,10 @@ import type { WrContextMenuPanel } from './context-menu-panel';
   selector: '[wrContextMenu]',
   host: {
     '(contextmenu)': 'onContextMenu($event)',
+    '(touchstart)': 'onTouchStart($event)',
+    '(touchmove)': 'onTouchMove($event)',
+    '(touchend)': 'onTouchEnd($event)',
+    '(touchcancel)': 'onTouchEnd($event)',
   },
 })
 export class WrContextMenu {
@@ -89,20 +93,90 @@ export class WrContextMenu {
    */
   private static readonly LEAVE_DELAY = 240;
 
+  /** Hold duration (ms) before a stationary touch press opens the menu. */
+  private static readonly LONG_PRESS_MS = 500;
+  /** Movement (px) that reclassifies a press as a scroll and cancels it. */
+  private static readonly LONG_PRESS_MOVE_TOLERANCE = 10;
+
+  private longPressTimer: ReturnType<typeof setTimeout> | null = null;
+  private touchStartX = 0;
+  private touchStartY = 0;
+  private longPressFired = false;
+  private suppressContextMenuUntil = 0;
+
   constructor() {
-    this.destroyRef.onDestroy(() => this.closeOverlay());
+    this.destroyRef.onDestroy(() => {
+      this.clearLongPress();
+      this.closeOverlay();
+    });
   }
 
   /** @internal Right-click handler — opens at the pointer (or re-positions if already open). */
   protected onContextMenu(event: MouseEvent): void {
     event.preventDefault();
     event.stopPropagation();
+    // A touch long-press just opened the menu; ignore the synthetic
+    // `contextmenu` some platforms (Android) fire at the same threshold so we
+    // don't close-and-reopen with a flicker.
+    if (performance.now() < this.suppressContextMenuUntil) return;
     // Re-open at the new position even if it was already open.
     // Use page coords (document-relative) so the menu anchors to the
     // zone it was opened over — scrolling the page carries the menu
     // along with the content, matching native + PrimeNG behavior.
     this.closeOverlay();
     this.openOverlay(event.pageX, event.pageY);
+  }
+
+  /**
+   * @internal Touch long-press → open the menu. Native `contextmenu` is
+   * unreliable on touch (iOS doesn't fire it, Android's timing varies), so we
+   * detect the press ourselves: a stationary hold for `LONG_PRESS_MS` opens
+   * the menu at the touch point; moving the finger reclassifies it as a
+   * scroll and cancels.
+   */
+  protected onTouchStart(event: TouchEvent): void {
+    const touch = event.touches[0];
+    if (!touch) return;
+    this.touchStartX = touch.pageX;
+    this.touchStartY = touch.pageY;
+    this.longPressFired = false;
+    this.clearLongPress();
+    this.longPressTimer = setTimeout(() => {
+      this.longPressTimer = null;
+      this.longPressFired = true;
+      this.suppressContextMenuUntil = performance.now() + 700;
+      this.closeOverlay();
+      this.openOverlay(this.touchStartX, this.touchStartY);
+    }, WrContextMenu.LONG_PRESS_MS);
+  }
+
+  /** @internal Cancel a pending long-press once the finger travels (a scroll). */
+  protected onTouchMove(event: TouchEvent): void {
+    if (this.longPressTimer === null) return;
+    const touch = event.touches[0];
+    if (!touch) return;
+    const moved =
+      Math.abs(touch.pageX - this.touchStartX) > WrContextMenu.LONG_PRESS_MOVE_TOLERANCE ||
+      Math.abs(touch.pageY - this.touchStartY) > WrContextMenu.LONG_PRESS_MOVE_TOLERANCE;
+    if (moved) this.clearLongPress();
+  }
+
+  /** @internal Release — drop a pending press; swallow the synthetic click a fired press would emit. */
+  protected onTouchEnd(event: TouchEvent): void {
+    this.clearLongPress();
+    if (this.longPressFired) {
+      this.longPressFired = false;
+      // Stop the browser turning this long-press into a synthetic click that
+      // would land outside the freshly-opened menu and dismiss it.
+      event.preventDefault();
+    }
+  }
+
+  private clearLongPress(): void {
+    if (this.longPressTimer !== null) {
+      clearTimeout(this.longPressTimer);
+      this.longPressTimer = null;
+    }
   }
 
   /** Close the menu. */

--- a/projects/showcase/app/components/context-menu/context-menu.html
+++ b/projects/showcase/app/components/context-menu/context-menu.html
@@ -1,17 +1,19 @@
 <ngwr-doc-page
   title="Context Menu"
-  description="Attach `[wrContextMenu]` to any element to open a `<wr-context-menu>` at the pointer position on right-click. Native browser menu is suppressed on the host."
-  [keywords]="['context menu', 'right click', 'menu', 'submenu', 'wr-context-menu']"
+  description="Attach `[wrContextMenu]` to any element to open a `<wr-context-menu>` at the pointer position on right-click — or a long-press on touch. Native browser menu is suppressed on the host."
+  [keywords]="['context menu', 'right click', 'long press', 'menu', 'submenu', 'wr-context-menu']"
   [labels]="['Overlay']"
 >
   <ngwr-doc-section title="Installation">
     <ngwr-doc-code [code]="snippets.install" language="angular-ts" />
   </ngwr-doc-section>
 
-  <ngwr-doc-section title="Basic" description="Right-click the area below.">
+  <ngwr-doc-section title="Basic" description="Right-click — or long-press on touch — the area below.">
     <ngwr-doc-code [code]="snippets.basic" language="angular-html" />
     <ngwr-doc-snippet code="">
-      <div [wrContextMenu]="basicMenu" class="ngwr-cm-demo">Right-click here — last action: {{ last || '(none)' }}</div>
+      <div [wrContextMenu]="basicMenu" class="ngwr-cm-demo">
+        Right-click or long-press — last action: {{ last || '(none)' }}
+      </div>
 
       <wr-context-menu #basicMenu>
         <wr-context-menu-item icon="copy" (click)="pick('copy')">Copy</wr-context-menu-item>


### PR DESCRIPTION
- **touchstart** records the point and starts a 500ms timer; firing opens the menu at the touch position (reusing the existing `openOverlay`).
- **touchmove** past 10px reclassifies it as a scroll and cancels — so scrolling over the host never triggers a menu.
- **touchend** drops a pending press, and on a *fired* press `preventDefault`s to swallow the synthetic click that would otherwise land outside the fresh menu and dismiss it.
- A 700ms suppress window after a long-press makes the directive ignore the synthetic `contextmenu` Android fires at the same threshold, so it doesn't close-and-reopen with a flicker. The right-click path is otherwise untouched.