### PR TITLE
feat(drag-drop): touch start-delay so lists stay scrollable

### DIFF
--- a/projects/lib/drag-drop/sortable-list.html
+++ b/projects/lib/drag-drop/sortable-list.html
@@ -6,7 +6,13 @@
   (cdkDropListDropped)="onDrop($event)"
 >
   @for (item of items(); track trackBy()($index, item)) {
-    <div cdkDrag class="wr-sortable-list__item" [cdkDragDisabled]="disabled()" [cdkDragLockAxis]="lockAxis() ?? null">
+    <div
+      cdkDrag
+      class="wr-sortable-list__item"
+      [cdkDragDisabled]="disabled()"
+      [cdkDragLockAxis]="lockAxis() ?? null"
+      [cdkDragStartDelay]="dragStartDelay()"
+    >
       <ng-container *ngTemplateOutlet="rowTemplate(); context: { $implicit: item, index: $index }" />
     </div>
   }

--- a/projects/lib/drag-drop/sortable-list.ts
+++ b/projects/lib/drag-drop/sortable-list.ts
@@ -56,6 +56,16 @@ export class WrSortableList<T = unknown> {
   /** Locked axis — restrict drag movement to one axis even diagonally. */
   readonly lockAxis = input<'x' | 'y' | undefined>(undefined);
 
+  /**
+   * Delay (ms) before a drag begins after the pointer goes down. The touch
+   * delay is the fix for the classic CDK touch snag: without it, the
+   * `touch-action: none` CDK puts on each item blocks scrolling the list on a
+   * phone. With a small touch delay, a quick swipe scrolls and a brief hold
+   * starts the drag; mouse stays instant. Pass a single number to apply one
+   * delay to both pointers. @default { touch: 150, mouse: 0 }
+   */
+  readonly dragStartDelay = input<number | { touch: number; mouse: number }>({ touch: 150, mouse: 0 });
+
   /** `trackBy` for the inner `@for`. Defaults to identity. */
   readonly trackBy = input<(index: number, item: T) => unknown>((_, item) => item);
 

--- a/projects/showcase/app/components/drag-drop/drag-drop.html
+++ b/projects/showcase/app/components/drag-drop/drag-drop.html
@@ -1,7 +1,7 @@
 <ngwr-doc-page
   title="Drag & Drop"
-  description="`<wr-sortable-list>` wraps CDK's `cdkDropList` + `cdkDrag` with a signal-based two-way `[(items)]` binding. Includes the `[wrDragHandle]` helper and themed `.cdk-drag-preview` / `.cdk-drag-placeholder` defaults."
-  [keywords]="['drag-drop', 'sortable', 'wr-sortable-list', 'wrDragHandle', 'cdk-drag', 'reorder']"
+  description="`<wr-sortable-list>` wraps CDK's `cdkDropList` + `cdkDrag` with a signal-based two-way `[(items)]` binding. Includes the `[wrDragHandle]` helper and themed `.cdk-drag-preview` / `.cdk-drag-placeholder` defaults. Touch-ready: a default touch start-delay lets a quick swipe scroll the list while a hold begins a drag."
+  [keywords]="['drag-drop', 'sortable', 'wr-sortable-list', 'wrDragHandle', 'cdk-drag', 'reorder', 'touch']"
   [labels]="['Component']"
 >
   <ngwr-doc-section title="Import">

--- a/projects/showcase/app/components/drag-drop/drag-drop.ts
+++ b/projects/showcase/app/components/drag-drop/drag-drop.ts
@@ -78,6 +78,13 @@ export default class DragDropPage {
     { name: 'disabled', description: 'Disable dragging.', type: 'boolean', default: 'false' },
     { name: 'lockAxis', description: 'Restrict drag movement to one axis.', type: "'x' | 'y'", default: '—' },
     {
+      name: 'dragStartDelay',
+      description:
+        'Delay (ms) before a drag begins. The touch delay lets a quick swipe scroll the list while a brief hold starts the drag; mouse stays instant.',
+      type: 'number | { touch: number; mouse: number }',
+      default: '{ touch: 150, mouse: 0 }',
+    },
+    {
       name: 'trackBy',
       description: '`trackBy` for the inner `@for`.',
       type: '(i, item) => unknown',


### PR DESCRIPTION
- New `dragStartDelay` input (`number | { touch: number; mouse: number }`), passed through to `[cdkDragStartDelay]`. **Default `{ touch: 150, mouse: 0 }`** — a quick swipe scrolls the list, a brief hold starts a drag; mouse stays instant (non-breaking for pointer users).
- Documented in the showcase API table + page description; `touch` keyword added.