### PR TITLE
feat: control-sizing contract + catalog-wide size/radius/font tokens

### DIFF
--- a/projects/lib/alert/styles/_index.scss
+++ b/projects/lib/alert/styles/_index.scss
@@ -52,7 +52,7 @@ $alert-colors: (
     margin: 0;
     color: var(--wr-alert-title);
     font-family: var(--wr-font-family-base);
-    font-size: 0.875rem;
+    font-size: var(--wr-text-sm);
     font-weight: 600;
     line-height: 1.25rem;
   }
@@ -61,7 +61,7 @@ $alert-colors: (
     margin: 0;
     color: var(--wr-alert-message);
     font-family: var(--wr-font-family-base);
-    font-size: 0.8125rem;
+    font-size: var(--wr-text-sm);
     line-height: 1.125rem;
   }
 

--- a/projects/lib/badge/styles/_index.scss
+++ b/projects/lib/badge/styles/_index.scss
@@ -20,7 +20,7 @@
   --wr-badge-padding-y: 0.25rem;
   --wr-badge-padding-x: 0.5rem;
   --wr-badge-radius: var(--wr-border-radius-sm);
-  --wr-badge-font-size: 0.75rem;
+  --wr-badge-font-size: var(--wr-text-xs);
   --wr-badge-line-height: 1rem;
   --wr-badge-font-weight: 600;
 
@@ -29,14 +29,14 @@
   &--sm {
     --wr-badge-padding-y: 0.125rem;
     --wr-badge-padding-x: 0.375rem;
-    --wr-badge-font-size: 0.625rem;
+    --wr-badge-font-size: 0.625rem; // 10px — intentional micro-count, below --wr-text-xs
     --wr-badge-line-height: 0.875rem;
   }
 
   &--lg {
     --wr-badge-padding-y: 0.375rem;
     --wr-badge-padding-x: 0.75rem;
-    --wr-badge-font-size: 0.875rem;
+    --wr-badge-font-size: var(--wr-text-sm);
     --wr-badge-line-height: 1.25rem;
   }
 

--- a/projects/lib/badge/styles/_index.scss
+++ b/projects/lib/badge/styles/_index.scss
@@ -9,11 +9,15 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  min-height: var(--wr-badge-min-height);
   padding: var(--wr-badge-padding-y) var(--wr-badge-padding-x);
   border-radius: var(--wr-badge-radius);
   font-size: var(--wr-badge-font-size);
   font-weight: var(--wr-badge-font-weight);
-  line-height: var(--wr-badge-line-height);
+  // line-height 1 + min-height: flex centres the tight glyph box vertically,
+  // instead of line-height baking in asymmetric leading (which left small
+  // sizes looking top-heavy).
+  line-height: 1;
   white-space: nowrap;
 
   // Defaults — sized modifiers override these
@@ -21,7 +25,7 @@
   --wr-badge-padding-x: 0.5rem;
   --wr-badge-radius: var(--wr-border-radius-sm);
   --wr-badge-font-size: var(--wr-text-xs);
-  --wr-badge-line-height: 1rem;
+  --wr-badge-min-height: 1.5rem;
   --wr-badge-font-weight: 600;
 
   // Sizes
@@ -30,14 +34,14 @@
     --wr-badge-padding-y: 0.125rem;
     --wr-badge-padding-x: 0.375rem;
     --wr-badge-font-size: 0.625rem; // 10px — intentional micro-count, below --wr-text-xs
-    --wr-badge-line-height: 0.875rem;
+    --wr-badge-min-height: 1.125rem;
   }
 
   &--lg {
     --wr-badge-padding-y: 0.375rem;
     --wr-badge-padding-x: 0.75rem;
     --wr-badge-font-size: var(--wr-text-sm);
-    --wr-badge-line-height: 1.25rem;
+    --wr-badge-min-height: 2rem;
   }
 
   // Shape — default `rounded` keeps the small radius from the defaults

--- a/projects/lib/badge/styles/_tag.scss
+++ b/projects/lib/badge/styles/_tag.scss
@@ -17,7 +17,7 @@
   --wr-tag-radius: var(--wr-border-radius-sm);
   --wr-tag-padding-y: 0.125rem;
   --wr-tag-padding-x: 0.5rem;
-  --wr-tag-font-size: 0.75rem;
+  --wr-tag-font-size: var(--wr-text-xs);
   --wr-tag-font-weight: 500;
   --wr-tag-line-height: 1rem;
 

--- a/projects/lib/breadcrumbs/styles/_index.scss
+++ b/projects/lib/breadcrumbs/styles/_index.scss
@@ -12,7 +12,7 @@
 
   display: block;
   font-family: var(--wr-font-family-base);
-  font-size: 0.875rem;
+  font-size: var(--wr-text-sm);
   color: var(--wr-breadcrumbs-color);
 
   &__nav {

--- a/projects/lib/button/styles/_index.scss
+++ b/projects/lib/button/styles/_index.scss
@@ -20,13 +20,13 @@
   --wr-btn-color: var(--wr-color-dark);
   --wr-btn-bg: var(--wr-color-white);
   --wr-btn-border: var(--wr-color-light);
-  --wr-btn-radius: var(--wr-border-radius-sm);
+  --wr-btn-radius: var(--wr-control-radius-md);
   --wr-btn-gap: 0.375rem;
-  --wr-btn-padding-y: 0.5rem;
-  --wr-btn-padding-x: 1rem;
-  --wr-btn-font-size: 0.875rem;
+  --wr-btn-padding-y: var(--wr-control-padding-y-md);
+  --wr-btn-padding-x: 0.875rem; // 14px — buttons sit a touch wider than input/select
+  --wr-btn-font-size: var(--wr-control-font-size-md);
   --wr-btn-font-weight: 500;
-  --wr-btn-line-height: 1.25rem;
+  --wr-btn-line-height: var(--wr-control-line-height-md);
   --wr-btn-icon-size: 1rem;
 
   color: var(--wr-btn-color);
@@ -74,24 +74,26 @@
     min-width: 0;
   }
 
-  // Sizes — consistent 28 / 36 / 44 px scale (each +8px tall).
-  // Padding, font, line-height, icon, and gap all step up together so
-  // the proportions stay visually identical between sizes.
+  // Sizes — share the `--wr-control-*` contract (22 / 30 / 36 px) so button,
+  // input and select line up in a row. Buttons keep a slightly wider padding-x
+  // (12 / 14 / 18) than input/select; gap + icon step with the size.
   &--sm {
+    --wr-btn-radius: var(--wr-control-radius-sm);
     --wr-btn-gap: 0.25rem;
-    --wr-btn-padding-y: 0.375rem; // 6px
+    --wr-btn-padding-y: var(--wr-control-padding-y-sm);
     --wr-btn-padding-x: 0.75rem; // 12px
-    --wr-btn-font-size: 0.75rem; // 12px
-    --wr-btn-line-height: 1rem; // 16px
+    --wr-btn-font-size: var(--wr-control-font-size-sm);
+    --wr-btn-line-height: var(--wr-control-line-height-sm);
     --wr-btn-icon-size: 0.875rem; // 14px
   }
 
   &--lg {
+    --wr-btn-radius: var(--wr-control-radius-lg);
     --wr-btn-gap: 0.5rem;
-    --wr-btn-padding-y: 0.625rem; // 10px
-    --wr-btn-padding-x: 1.5rem; // 24px
-    --wr-btn-font-size: 1rem; // 16px
-    --wr-btn-line-height: 1.5rem; // 24px
+    --wr-btn-padding-y: var(--wr-control-padding-y-lg);
+    --wr-btn-padding-x: 1.125rem; // 18px
+    --wr-btn-font-size: var(--wr-control-font-size-lg);
+    --wr-btn-line-height: var(--wr-control-line-height-lg);
     --wr-btn-icon-size: 1.125rem; // 18px
   }
 

--- a/projects/lib/calendar-heatmap/styles/_index.scss
+++ b/projects/lib/calendar-heatmap/styles/_index.scss
@@ -59,6 +59,8 @@
   &__cell {
     width: var(--wr-heatmap-cell-size);
     height: var(--wr-heatmap-cell-size);
+    // 2px — intentional micro-radius for the tiny (~11px) cells; the control /
+    // border-radius tokens (5px+) would read as near-circles at this size.
     border-radius: 2px;
     transition: transform var(--wr-transition-base);
 

--- a/projects/lib/calendar/styles/_index.scss
+++ b/projects/lib/calendar/styles/_index.scss
@@ -42,7 +42,7 @@
     color: inherit;
     text-align: center;
     font-family: inherit;
-    font-size: 0.875rem;
+    font-size: var(--wr-text-sm);
     font-weight: 600;
     line-height: 1.5rem;
     border-radius: var(--wr-calendar-day-radius);
@@ -73,7 +73,7 @@
     height: 1.75rem;
     border-radius: var(--wr-calendar-day-radius);
     color: var(--wr-calendar-muted);
-    font-size: 1.125rem;
+    font-size: var(--wr-text-lg);
     line-height: 1;
     cursor: pointer;
     transition:
@@ -106,7 +106,7 @@
   &__weekday {
     text-align: center;
     color: var(--wr-calendar-muted);
-    font-size: 0.6875rem;
+    font-size: var(--wr-text-xs);
     font-weight: 600;
     line-height: 1.5rem;
     text-transform: uppercase;
@@ -134,7 +134,7 @@
     margin: 0;
     height: var(--wr-calendar-cell-size);
     font-family: inherit;
-    font-size: 0.8125rem;
+    font-size: var(--wr-text-sm);
     line-height: var(--wr-calendar-cell-size);
     color: var(--wr-calendar-color);
     border-radius: var(--wr-calendar-day-radius);
@@ -208,7 +208,7 @@
     margin: 0;
     height: 2.5rem;
     font-family: inherit;
-    font-size: 0.8125rem;
+    font-size: var(--wr-text-sm);
     line-height: 2.5rem;
     color: var(--wr-calendar-color);
     border-radius: var(--wr-calendar-day-radius);

--- a/projects/lib/cascader/cascader.html
+++ b/projects/lib/cascader/cascader.html
@@ -58,7 +58,13 @@
 </button>
 
 <ng-template #panelTpl>
-  <div class="wr-cascader-panel" role="menu" [attr.id]="panelId">
+  <div
+    class="wr-cascader-panel"
+    [class.wr-cascader-panel--sm]="size() === 'sm'"
+    [class.wr-cascader-panel--lg]="size() === 'lg'"
+    role="menu"
+    [attr.id]="panelId"
+  >
     @for (col of columns(); track $index; let colIndex = $index) {
       <ul class="wr-cascader__col" role="menu">
         @for (opt of col; track opt.value) {

--- a/projects/lib/cascader/cascader.ts
+++ b/projects/lib/cascader/cascader.ts
@@ -62,6 +62,8 @@ let panelUid = 0;
  *
  * @see https://ngwr.dev/components/cascader
  */
+export type WrCascaderSize = 'sm' | 'md' | 'lg';
+
 @Component({
   selector: 'wr-cascader',
   templateUrl: './cascader.html',
@@ -86,6 +88,9 @@ export class WrCascader<T = string> implements ControlValueAccessor {
 
   /** Disable the cascader. */
   readonly disabled = input(false, { transform: coerceBooleanProperty });
+
+  /** Control size — shares the `--wr-control-*` contract. @default 'md' */
+  readonly size = input<WrCascaderSize>('md');
 
   /** Show a clear-all (×) button on the trigger when a path is selected. @default true */
   readonly clearable = input(true, { transform: coerceBooleanProperty });
@@ -153,6 +158,8 @@ export class WrCascader<T = string> implements ControlValueAccessor {
 
   protected readonly classes = computed(() => {
     const parts = ['wr-cascader'];
+    const size = this.size();
+    if (size !== 'md') parts.push(`wr-cascader--${size}`);
     if (this.open()) parts.push('wr-cascader--open');
     if (this.isDisabled()) parts.push('wr-cascader--disabled');
     return parts.join(' ');

--- a/projects/lib/cascader/public-api.ts
+++ b/projects/lib/cascader/public-api.ts
@@ -1,1 +1,1 @@
-export { WrCascader, type WrCascaderOption } from './cascader';
+export { WrCascader, type WrCascaderOption, type WrCascaderSize } from './cascader';

--- a/projects/lib/cascader/styles/_index.scss
+++ b/projects/lib/cascader/styles/_index.scss
@@ -6,11 +6,11 @@
   --wr-cascader-color: var(--wr-color-dark);
   --wr-cascader-bg: var(--wr-color-white);
   --wr-cascader-border: var(--wr-color-light);
-  --wr-cascader-radius: var(--wr-border-radius-base);
-  --wr-cascader-padding-y: 0.4375rem;
-  --wr-cascader-padding-x: 0.75rem;
-  --wr-cascader-font-size: 0.875rem;
-  --wr-cascader-line-height: 1.25rem;
+  --wr-cascader-radius: var(--wr-control-radius-md);
+  --wr-cascader-padding-y: var(--wr-control-padding-y-md);
+  --wr-cascader-padding-x: var(--wr-control-padding-x-md);
+  --wr-cascader-font-size: var(--wr-control-font-size-md);
+  --wr-cascader-line-height: var(--wr-control-line-height-md);
   --wr-cascader-col-width: 12rem;
   --wr-cascader-max-height: 16rem;
 
@@ -20,6 +20,23 @@
   &--disabled {
     --wr-cascader-color: var(--wr-color-medium);
     --wr-cascader-bg: rgba(var(--wr-color-light-rgb), 0.35);
+  }
+
+  // Sizes — trigger on the control contract (sm 22 / md 30 / lg 36).
+  &--sm {
+    --wr-cascader-radius: var(--wr-control-radius-sm);
+    --wr-cascader-padding-y: var(--wr-control-padding-y-sm);
+    --wr-cascader-padding-x: var(--wr-control-padding-x-sm);
+    --wr-cascader-font-size: var(--wr-control-font-size-sm);
+    --wr-cascader-line-height: var(--wr-control-line-height-sm);
+  }
+
+  &--lg {
+    --wr-cascader-radius: var(--wr-control-radius-lg);
+    --wr-cascader-padding-y: var(--wr-control-padding-y-lg);
+    --wr-cascader-padding-x: var(--wr-control-padding-x-lg);
+    --wr-cascader-font-size: var(--wr-control-font-size-lg);
+    --wr-cascader-line-height: var(--wr-control-line-height-lg);
   }
 
   &__trigger {
@@ -108,44 +125,66 @@
 }
 
 .wr-cascader-panel {
+  // Option sizing — mirrored from the trigger size (panel is portaled, so it
+  // can't inherit the host size class). Default md.
+  --wr-cascader-opt-font: var(--wr-control-font-size-md);
+  --wr-cascader-opt-py: 0.5rem;
+
   display: flex;
   background: var(--wr-color-white);
   border: 1px solid var(--wr-color-light);
   border-radius: var(--wr-border-radius-base);
   box-shadow: var(--wr-shadow-overlay);
   font-family: var(--wr-font-family-base);
-  font-size: 0.875rem;
+  font-size: var(--wr-cascader-opt-font);
   overflow: hidden;
+
+  &--sm {
+    --wr-cascader-opt-font: var(--wr-control-font-size-sm);
+    --wr-cascader-opt-py: 0.375rem;
+  }
+
+  &--lg {
+    --wr-cascader-opt-font: var(--wr-control-font-size-lg);
+    --wr-cascader-opt-py: 0.625rem;
+  }
 
   .wr-cascader__col {
     list-style: none;
     margin: 0;
-    padding: 0.25rem 0;
+    // Inset padding so options read as rounded pills, matching the select panel.
+    padding: 0.25rem;
     width: var(--wr-cascader-col-width, 12rem);
     max-height: var(--wr-cascader-max-height, 16rem);
     overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
 
     + .wr-cascader__col {
       border-left: 1px solid var(--wr-color-light);
     }
   }
 
+  // Options mirror .wr-option (rounded pill, soft primary tint when active).
   .wr-cascader__opt {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    padding: 0.5rem 0.75rem;
+    padding: var(--wr-cascader-opt-py) 0.625rem;
+    border-radius: var(--wr-border-radius-sm);
     color: var(--wr-color-dark);
     cursor: pointer;
-    transition: background 0.12s ease;
+    transition: background var(--wr-transition-short);
 
     &:hover {
-      background: rgba(var(--wr-color-light-rgb), 0.5);
+      background: rgba(var(--wr-color-light-rgb), 0.4);
     }
 
     &--active {
-      background: rgba(var(--wr-color-primary-rgb), 0.08);
+      background: rgba(var(--wr-color-primary-rgb), 0.1);
       color: var(--wr-color-primary);
+      font-weight: 500;
     }
 
     &--disabled {

--- a/projects/lib/checkbox/checkbox.ts
+++ b/projects/lib/checkbox/checkbox.ts
@@ -37,6 +37,8 @@ import { WR_CHECKBOX_GROUP } from './tokens';
  *
  * @see https://ngwr.dev/components/checkbox
  */
+export type WrCheckboxSize = 'sm' | 'md' | 'lg';
+
 @Component({
   selector: 'wr-checkbox',
   templateUrl: './checkbox.html',
@@ -73,6 +75,9 @@ export class WrCheckbox implements ControlValueAccessor {
    */
   readonly disabled = input(false, { transform: coerceBooleanProperty });
 
+  /** Control size — shares the `--wr-control-*` contract. @default 'md' */
+  readonly size = input<WrCheckboxSize>('md');
+
   /**
    * Optional icon name rendered inside the box when checked, in place of the
    * default checkmark. Use any registered NGWR icon.
@@ -98,6 +103,8 @@ export class WrCheckbox implements ControlValueAccessor {
 
   protected readonly classes = computed(() => {
     const parts = ['wr-checkbox'];
+    const size = this.size();
+    if (size !== 'md') parts.push(`wr-checkbox--${size}`);
     if (this.checked()) parts.push('wr-checkbox--checked');
     if (this.effectiveDisabled()) parts.push('wr-checkbox--disabled');
     return parts.join(' ');

--- a/projects/lib/checkbox/public-api.ts
+++ b/projects/lib/checkbox/public-api.ts
@@ -1,3 +1,4 @@
 export { WrCheckbox } from './checkbox';
+export type { WrCheckboxSize } from './checkbox';
 export { WrCheckboxGroup } from './checkbox-group';
 export { WR_CHECKBOX_GROUP, type WrCheckboxGroupContext } from './tokens';

--- a/projects/lib/checkbox/styles/_index.scss
+++ b/projects/lib/checkbox/styles/_index.scss
@@ -1,8 +1,10 @@
 @use '../../theme/styles' as theme;
 
 .wr-checkbox {
-  --wr-checkbox-size: 1.125rem;
-  --wr-checkbox-radius: var(--wr-border-radius-sm);
+  --wr-checkbox-size: 1.125rem; // md box (18px)
+  --wr-checkbox-radius: var(--wr-control-radius-md);
+  --wr-checkbox-font-size: var(--wr-text-sm);
+  --wr-checkbox-line-height: var(--wr-control-line-height-md);
   --wr-checkbox-bg: var(--wr-color-white);
   --wr-checkbox-border: var(--wr-color-light);
   --wr-checkbox-mark: transparent;
@@ -12,8 +14,8 @@
   vertical-align: middle;
   color: var(--wr-checkbox-color);
   font-family: var(--wr-font-family-base);
-  font-size: 0.875rem;
-  line-height: 1.25rem;
+  font-size: var(--wr-checkbox-font-size);
+  line-height: var(--wr-checkbox-line-height);
 
   &__label {
     display: inline-flex;
@@ -74,6 +76,21 @@
 
   &__label:hover &__box {
     --wr-checkbox-border: var(--wr-color-primary);
+  }
+
+  // Sizes — box, radius, label font + line-height scale together.
+  &--sm {
+    --wr-checkbox-size: 1rem; // 16px
+    --wr-checkbox-radius: var(--wr-control-radius-sm);
+    --wr-checkbox-font-size: var(--wr-text-xs);
+    --wr-checkbox-line-height: var(--wr-control-line-height-sm);
+  }
+
+  &--lg {
+    --wr-checkbox-size: 1.25rem; // 20px
+    --wr-checkbox-radius: var(--wr-control-radius-lg);
+    --wr-checkbox-font-size: var(--wr-text-base);
+    --wr-checkbox-line-height: var(--wr-control-line-height-lg);
   }
 
   &--checked {

--- a/projects/lib/collapse/styles/_index.scss
+++ b/projects/lib/collapse/styles/_index.scss
@@ -28,7 +28,7 @@
     border: 0;
     color: inherit;
     font: inherit;
-    font-size: 0.9375rem;
+    font-size: var(--wr-text-base);
     font-weight: 500;
     text-align: left;
     cursor: pointer;

--- a/projects/lib/color-picker/styles/_index.scss
+++ b/projects/lib/color-picker/styles/_index.scss
@@ -129,7 +129,7 @@
 
   &__tabs {
     flex: 1 1 auto;
-    font-size: 0.75rem;
+    font-size: var(--wr-text-xs);
   }
 
   // Per-tab numeric inputs
@@ -159,7 +159,7 @@
       padding: 0.25rem 0.375rem;
       color: var(--wr-color-dark);
       font-family: var(--wr-font-family-mono, monospace);
-      font-size: 0.75rem;
+      font-size: var(--wr-text-xs);
       line-height: 1rem;
       text-align: center;
       outline: 0;
@@ -191,13 +191,13 @@
     text-align: left;
     text-transform: lowercase;
     padding: 0.3125rem 0.5rem;
-    font-size: 0.8125rem;
+    font-size: var(--wr-text-sm);
   }
 
   &__field-label {
     text-align: center;
     color: var(--wr-color-medium);
-    font-size: 0.625rem;
+    font-size: 0.625rem; // 10px — intentional micro R/G/B/A channel label, below --wr-text-xs
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.04em;

--- a/projects/lib/date-picker/styles/_index.scss
+++ b/projects/lib/date-picker/styles/_index.scss
@@ -118,7 +118,7 @@
     border-radius: var(--wr-border-radius-sm);
     color: var(--wr-time-picker-color);
     font-family: var(--wr-font-family-base);
-    font-size: 0.9375rem;
+    font-size: var(--wr-text-sm);
     line-height: 1.25rem;
     font-weight: 600;
     text-align: center;
@@ -157,14 +157,14 @@
     border-radius: var(--wr-border-radius-sm);
     color: var(--wr-time-picker-color);
     font-family: var(--wr-font-family-base);
-    font-size: 0.9375rem;
+    font-size: var(--wr-text-sm);
     font-weight: 600;
     user-select: none;
   }
 
   &__sep {
     color: var(--wr-time-picker-muted);
-    font-size: 1.125rem;
+    font-size: var(--wr-text-lg);
     font-weight: 600;
     line-height: 1;
     user-select: none;

--- a/projects/lib/dialog/styles/_index.scss
+++ b/projects/lib/dialog/styles/_index.scss
@@ -80,7 +80,7 @@
     margin: 0;
     padding: var(--wr-dialog-padding-y) var(--wr-dialog-padding-x);
     color: var(--wr-color-dark);
-    font-size: 1.0625rem;
+    font-size: var(--wr-text-lg);
     font-weight: 600;
     line-height: 1.5rem;
     border-bottom: 1px solid var(--wr-color-light);
@@ -90,7 +90,7 @@
     padding: var(--wr-dialog-padding-y) var(--wr-dialog-padding-x);
     overflow: auto;
     color: var(--wr-color-dark);
-    font-size: 0.9375rem;
+    font-size: var(--wr-text-base);
     line-height: 1.5rem;
   }
 

--- a/projects/lib/divider/styles/_index.scss
+++ b/projects/lib/divider/styles/_index.scss
@@ -15,7 +15,7 @@
   width: 100%;
   user-select: none;
   color: var(--wr-color-medium);
-  font-size: 0.8125rem;
+  font-size: var(--wr-text-sm);
   line-height: 1.125rem;
 
   &::before,

--- a/projects/lib/drawer/styles/_index.scss
+++ b/projects/lib/drawer/styles/_index.scss
@@ -39,20 +39,20 @@
   // Rounded leading corners
   // The edge facing the viewport interior. Common bottom-sheet styling.
   &--rounded.wr-drawer__panel--bottom {
-    border-top-left-radius: 1rem;
-    border-top-right-radius: 1rem;
+    border-top-left-radius: var(--wr-border-radius-lg);
+    border-top-right-radius: var(--wr-border-radius-lg);
   }
   &--rounded.wr-drawer__panel--top {
-    border-bottom-left-radius: 1rem;
-    border-bottom-right-radius: 1rem;
+    border-bottom-left-radius: var(--wr-border-radius-lg);
+    border-bottom-right-radius: var(--wr-border-radius-lg);
   }
   &--rounded.wr-drawer__panel--left {
-    border-top-right-radius: 1rem;
-    border-bottom-right-radius: 1rem;
+    border-top-right-radius: var(--wr-border-radius-lg);
+    border-bottom-right-radius: var(--wr-border-radius-lg);
   }
   &--rounded.wr-drawer__panel--right {
-    border-top-left-radius: 1rem;
-    border-bottom-left-radius: 1rem;
+    border-top-left-radius: var(--wr-border-radius-lg);
+    border-bottom-left-radius: var(--wr-border-radius-lg);
   }
 
   // Safe-area padding on the trailing edge

--- a/projects/lib/drawer/styles/_index.scss
+++ b/projects/lib/drawer/styles/_index.scss
@@ -96,7 +96,7 @@
     margin: 0;
     padding: 1rem 1.25rem;
     color: var(--wr-color-dark);
-    font-size: 1.0625rem;
+    font-size: var(--wr-text-lg);
     font-weight: 600;
     line-height: 1.5rem;
     border-bottom: 1px solid var(--wr-color-light);
@@ -106,7 +106,7 @@
     flex: 1 1 auto;
     padding: 1rem 1.25rem;
     overflow: auto;
-    font-size: 0.9375rem;
+    font-size: var(--wr-text-base);
     line-height: 1.5rem;
   }
 

--- a/projects/lib/dropdown/styles/_index.scss
+++ b/projects/lib/dropdown/styles/_index.scss
@@ -74,7 +74,7 @@
   border-radius: var(--wr-dropdown-item-radius);
   color: var(--wr-dropdown-item-color);
   font: inherit;
-  font-size: 0.875rem;
+  font-size: var(--wr-text-sm);
   line-height: 1.25rem;
   text-align: left;
   white-space: nowrap;

--- a/projects/lib/file-upload/styles/_index.scss
+++ b/projects/lib/file-upload/styles/_index.scss
@@ -57,7 +57,7 @@
     display: flex;
     flex-direction: column;
     gap: 0.125rem;
-    font-size: 0.875rem;
+    font-size: var(--wr-text-sm);
     line-height: 1.25rem;
 
     strong {
@@ -72,7 +72,7 @@
     small {
       margin-top: 0.25rem;
       color: var(--wr-color-medium);
-      font-size: 0.75rem;
+      font-size: var(--wr-text-xs);
     }
   }
 
@@ -106,7 +106,7 @@
     background: var(--wr-color-white);
     border: 1px solid var(--wr-color-light);
     @include theme.smooth-br(var(--wr-border-radius-base));
-    font-size: 0.875rem;
+    font-size: var(--wr-text-sm);
     line-height: 1.25rem;
   }
 

--- a/projects/lib/form/styles/_index.scss
+++ b/projects/lib/form/styles/_index.scss
@@ -8,7 +8,7 @@
 
   > label {
     color: var(--wr-color-medium);
-    font-size: 0.8125rem;
+    font-size: var(--wr-text-sm);
     font-weight: 500;
     line-height: 1.25rem;
     transition: color var(--wr-transition-base);
@@ -30,7 +30,7 @@
 .wr-form-error {
   display: block;
   color: var(--wr-color-danger);
-  font-size: 0.75rem;
+  font-size: var(--wr-text-xs);
   line-height: 1rem;
 }
 
@@ -45,7 +45,7 @@
     align-items: center;
     gap: 0.25rem;
     color: var(--wr-color-dark);
-    font-size: 0.875rem;
+    font-size: var(--wr-text-sm);
     font-weight: 500;
     line-height: 1.25rem;
   }
@@ -57,7 +57,7 @@
   &__optional {
     color: var(--wr-color-medium);
     font-weight: 400;
-    font-size: 0.8125rem;
+    font-size: var(--wr-text-sm);
   }
 
   &__control {
@@ -79,7 +79,7 @@
 
   &__error {
     color: var(--wr-color-danger);
-    font-size: 0.8125rem;
+    font-size: var(--wr-text-sm);
     line-height: 1.25;
   }
 

--- a/projects/lib/input-otp/input-otp.ts
+++ b/projects/lib/input-otp/input-otp.ts
@@ -22,7 +22,7 @@ import { type ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { noop } from 'ngwr/utils';
 
-import type { WrInputOtpMode } from './interfaces';
+import type { WrInputOtpMode, WrInputOtpSize } from './interfaces';
 
 /**
  * Fixed-length one-time-code input. Renders one `<input>` per character,
@@ -63,6 +63,9 @@ export class WrInputOtp implements ControlValueAccessor {
   /** Character set per cell. @default 'numeric' */
   readonly mode = input<WrInputOtpMode>('numeric');
 
+  /** Control size — shares the `--wr-control-*` contract. @default 'md' */
+  readonly size = input<WrInputOtpSize>('md');
+
   /** Mask the typed characters like a password. @default false */
   readonly mask = input(false, { transform: coerceBooleanProperty });
 
@@ -82,6 +85,8 @@ export class WrInputOtp implements ControlValueAccessor {
 
   protected readonly classes = computed(() => {
     const parts = ['wr-input-otp'];
+    const size = this.size();
+    if (size !== 'md') parts.push(`wr-input-otp--${size}`);
     if (this.effectiveDisabled()) parts.push('wr-input-otp--disabled');
     return parts.join(' ');
   });

--- a/projects/lib/input-otp/interfaces/index.ts
+++ b/projects/lib/input-otp/interfaces/index.ts
@@ -1,1 +1,2 @@
 export type { WrInputOtpMode } from './input-otp-mode';
+export type WrInputOtpSize = 'sm' | 'md' | 'lg';

--- a/projects/lib/input-otp/public-api.ts
+++ b/projects/lib/input-otp/public-api.ts
@@ -1,2 +1,2 @@
 export { WrInputOtp } from './input-otp';
-export type { WrInputOtpMode } from './interfaces';
+export type { WrInputOtpMode, WrInputOtpSize } from './interfaces';

--- a/projects/lib/input-otp/styles/_index.scss
+++ b/projects/lib/input-otp/styles/_index.scss
@@ -5,11 +5,14 @@
   --wr-input-otp-border: var(--wr-color-light);
   --wr-input-otp-color: var(--wr-color-dark);
   --wr-input-otp-focus: var(--wr-color-primary);
-  --wr-input-otp-size: 2.75rem;
+  --wr-input-otp-size: 2.5rem; // md cell (40px)
+  --wr-input-otp-font: var(--wr-text-lg); // 18px
+  --wr-input-otp-radius: var(--wr-control-radius-md);
+  --wr-input-otp-gap: 0.5rem;
 
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--wr-input-otp-gap);
   font-family: var(--wr-font-family-base);
 
   &__cell {
@@ -18,13 +21,13 @@
     padding: 0;
     text-align: center;
     font-family: var(--wr-font-family-mono, monospace);
-    font-size: 1.125rem;
+    font-size: var(--wr-input-otp-font);
     font-weight: 500;
     line-height: 1;
     color: var(--wr-input-otp-color);
     background: var(--wr-input-otp-bg);
     border: 1px solid var(--wr-input-otp-border);
-    @include theme.smooth-br(var(--wr-border-radius-base));
+    @include theme.smooth-br(var(--wr-input-otp-radius));
     appearance: none;
     transition:
       border-color var(--wr-transition-base),
@@ -45,6 +48,21 @@
       color: var(--wr-color-medium);
       cursor: not-allowed;
     }
+  }
+
+  // Sizes — cell, digit font, radius + gap scale together.
+  &--sm {
+    --wr-input-otp-size: 2rem; // 32px
+    --wr-input-otp-font: var(--wr-text-base); // 16px
+    --wr-input-otp-radius: var(--wr-control-radius-sm);
+    --wr-input-otp-gap: 0.375rem;
+  }
+
+  &--lg {
+    --wr-input-otp-size: 3rem; // 48px
+    --wr-input-otp-font: var(--wr-text-xl); // 20px
+    --wr-input-otp-radius: var(--wr-control-radius-lg);
+    --wr-input-otp-gap: 0.625rem;
   }
 
   &--disabled {

--- a/projects/lib/input/directives/wr-input.ts
+++ b/projects/lib/input/directives/wr-input.ts
@@ -8,6 +8,8 @@
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { Directive, computed, input } from '@angular/core';
 
+import type { WrInputSize } from '../interfaces';
+
 /**
  * Applies NGWR input styling to a native `<input>` element.
  *
@@ -34,11 +36,19 @@ import { Directive, computed, input } from '@angular/core';
   host: { '[class]': 'classes()' },
 })
 export class WrInput {
+  /**
+   * Control size. Named `wrSize` (not `size`) so it never clashes with the
+   * native `<input size>` attribute. @default 'md'
+   */
+  readonly wrSize = input<WrInputSize>('md');
+
   /** Pill-shaped corners. @default false */
   readonly rounded = input(false, { transform: coerceBooleanProperty });
 
   protected readonly classes = computed(() => {
     const parts = ['wr-input'];
+    const size = this.wrSize();
+    if (size !== 'md') parts.push(`wr-input--${size}`);
     if (this.rounded()) parts.push('wr-input--rounded');
     return parts.join(' ');
   });

--- a/projects/lib/input/interfaces/index.ts
+++ b/projects/lib/input/interfaces/index.ts
@@ -1,1 +1,2 @@
 export type { WrInputType } from './input-type';
+export type { WrInputSize } from './input-size';

--- a/projects/lib/input/interfaces/input-size.ts
+++ b/projects/lib/input/interfaces/input-size.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/thekhegay/ngwr/blob/main/LICENSE
+ */
+
+/** Control size for `[wrInput]` — shares the `--wr-control-*` contract. */
+export type WrInputSize = 'sm' | 'md' | 'lg';

--- a/projects/lib/input/public-api.ts
+++ b/projects/lib/input/public-api.ts
@@ -1,4 +1,4 @@
 export { WrInput, WrInputPrefix, WrInputSuffix } from './directives';
 export { WrInputGroup } from './input-group';
 export { WrPasswordToggle } from './password-toggle';
-export type { WrInputType } from './interfaces';
+export type { WrInputType, WrInputSize } from './interfaces';

--- a/projects/lib/input/styles/_index.scss
+++ b/projects/lib/input/styles/_index.scss
@@ -139,7 +139,7 @@
     user-select: none;
     font-weight: 500;
     font-family: var(--wr-font-family-base);
-    font-size: 0.875rem;
+    font-size: var(--wr-text-sm);
     line-height: 1.25rem;
   }
 

--- a/projects/lib/input/styles/_index.scss
+++ b/projects/lib/input/styles/_index.scss
@@ -10,12 +10,12 @@
   --wr-input-placeholder: rgba(var(--wr-color-medium-rgb), 0.7);
   --wr-input-bg: var(--wr-color-white);
   --wr-input-border: var(--wr-color-light);
-  --wr-input-radius: var(--wr-border-radius-base);
+  --wr-input-radius: var(--wr-control-radius-md);
   --wr-input-ring: transparent;
-  --wr-input-padding-y: 0.4375rem;
-  --wr-input-padding-x: 0.75rem;
-  --wr-input-font-size: 0.875rem;
-  --wr-input-line-height: 1.25rem;
+  --wr-input-padding-y: var(--wr-control-padding-y-md);
+  --wr-input-padding-x: var(--wr-control-padding-x-md);
+  --wr-input-font-size: var(--wr-control-font-size-md);
+  --wr-input-line-height: var(--wr-control-line-height-md);
 
   display: inline-block;
   width: 100%;
@@ -57,6 +57,25 @@
     cursor: not-allowed;
   }
 
+  // Sizes — share the `--wr-control-*` contract (22 / 30 / 36 px). Declared
+  // before `--rounded` so the pill modifier's radius / padding-x still win
+  // when both classes are present.
+  &--sm {
+    --wr-input-radius: var(--wr-control-radius-sm);
+    --wr-input-padding-y: var(--wr-control-padding-y-sm);
+    --wr-input-padding-x: var(--wr-control-padding-x-sm);
+    --wr-input-font-size: var(--wr-control-font-size-sm);
+    --wr-input-line-height: var(--wr-control-line-height-sm);
+  }
+
+  &--lg {
+    --wr-input-radius: var(--wr-control-radius-lg);
+    --wr-input-padding-y: var(--wr-control-padding-y-lg);
+    --wr-input-padding-x: var(--wr-control-padding-x-lg);
+    --wr-input-font-size: var(--wr-control-font-size-lg);
+    --wr-input-line-height: var(--wr-control-line-height-lg);
+  }
+
   &--rounded {
     --wr-input-radius: var(--wr-border-radius-pill);
     --wr-input-padding-x: 1rem;
@@ -70,7 +89,7 @@
 // `[wrInputPrefix]` / `[wrInputSuffix]` / `<wr-password-toggle>` siblings.
 //
 .wr-input-group {
-  --wr-input-group-radius: var(--wr-border-radius-base);
+  --wr-input-group-radius: var(--wr-control-radius-md);
   --wr-input-group-bg: var(--wr-color-white);
   --wr-input-group-border: var(--wr-color-light);
   --wr-input-group-ring: transparent;

--- a/projects/lib/keyboard/styles/_index.scss
+++ b/projects/lib/keyboard/styles/_index.scss
@@ -4,7 +4,7 @@
   --wr-kbd-border: rgba(var(--wr-color-dark-rgb), 0.18);
   --wr-kbd-border-bottom: rgba(var(--wr-color-dark-rgb), 0.32);
   --wr-kbd-color: var(--wr-color-dark);
-  --wr-kbd-radius: 4px;
+  --wr-kbd-radius: var(--wr-control-radius-md);
   // Shadow uses the always-black backdrop token, not `--wr-color-dark-rgb`
   // — the dark RGB flips to light in dark mode, which would turn the
   // 1px drop-shadow into a top highlight.
@@ -33,23 +33,25 @@
   white-space: nowrap;
 
   &--sm {
+    --wr-kbd-radius: var(--wr-control-radius-sm);
     min-width: 1.375rem;
     height: 1.375rem;
     padding: 0 0.3125rem;
-    font-size: 0.6875rem;
+    font-size: var(--wr-text-xs);
   }
 
   &--md {
     min-width: 1.75rem;
     height: 1.75rem;
     padding: 0 0.4375rem;
-    font-size: 0.8125rem;
+    font-size: var(--wr-text-sm);
   }
 
   &--lg {
+    --wr-kbd-radius: var(--wr-control-radius-lg);
     min-width: 2.125rem;
     height: 2.125rem;
     padding: 0 0.5625rem;
-    font-size: 0.9375rem;
+    font-size: var(--wr-text-base);
   }
 }

--- a/projects/lib/lightbox/styles/_index.scss
+++ b/projects/lib/lightbox/styles/_index.scss
@@ -130,7 +130,7 @@
   &__caption {
     color: rgba(255, 255, 255, 0.85);
     font-family: var(--wr-font-family-base);
-    font-size: 0.9375rem;
+    font-size: var(--wr-text-sm);
     text-align: center;
     max-width: 60ch;
   }

--- a/projects/lib/list/styles/_index.scss
+++ b/projects/lib/list/styles/_index.scss
@@ -16,7 +16,7 @@
 
   display: block;
   font-family: var(--wr-font-family-base);
-  font-size: 0.9375rem;
+  font-size: var(--wr-text-sm);
   color: var(--wr-color-dark);
   background: var(--wr-list-bg);
 

--- a/projects/lib/mention/styles/_index.scss
+++ b/projects/lib/mention/styles/_index.scss
@@ -13,7 +13,7 @@
   @include theme.smooth-br(var(--wr-border-radius-base));
   box-shadow: var(--wr-shadow-overlay);
   font-family: var(--wr-font-family-base);
-  font-size: 0.875rem;
+  font-size: var(--wr-text-sm);
   color: var(--wr-color-dark);
   overflow: hidden;
 
@@ -41,7 +41,7 @@
   &__empty {
     padding: 0.5rem 0.75rem;
     color: var(--wr-color-medium);
-    font-size: 0.875rem;
+    font-size: var(--wr-text-sm);
     user-select: none;
   }
 }

--- a/projects/lib/pagination/styles/_index.scss
+++ b/projects/lib/pagination/styles/_index.scss
@@ -36,7 +36,7 @@
   &__total {
     color: var(--wr-color-medium);
     font-family: var(--wr-font-family-base);
-    font-size: 0.8125rem;
+    font-size: var(--wr-text-sm);
   }
 
   &__nav {
@@ -73,7 +73,7 @@
     padding: 0 0.375rem;
     color: var(--wr-color-dark);
     font-family: var(--wr-font-family-base);
-    font-size: 0.8125rem;
+    font-size: var(--wr-text-sm);
     font-variant-numeric: tabular-nums;
     white-space: nowrap;
   }
@@ -91,7 +91,7 @@
 
     .wr-btn {
       --wr-btn-padding-x: 0.375rem;
-      --wr-btn-font-size: 0.6875rem;
+      --wr-btn-font-size: var(--wr-text-xs);
       --wr-btn-line-height: 0.875rem;
       --wr-btn-icon-size: 0.75rem;
     }
@@ -110,7 +110,7 @@
 
     .wr-btn {
       --wr-btn-padding-x: 1rem;
-      --wr-btn-font-size: 1.125rem;
+      --wr-btn-font-size: var(--wr-text-lg);
       --wr-btn-line-height: 1.75rem;
       --wr-btn-icon-size: 1.25rem;
     }

--- a/projects/lib/popconfirm/styles/_index.scss
+++ b/projects/lib/popconfirm/styles/_index.scss
@@ -20,7 +20,7 @@
 .wr-popconfirm {
   &__message {
     margin: 0 0 0.625rem;
-    font-size: 0.875rem;
+    font-size: var(--wr-text-sm);
     line-height: 1.25rem;
   }
 

--- a/projects/lib/popover/styles/_index.scss
+++ b/projects/lib/popover/styles/_index.scss
@@ -36,7 +36,7 @@
   color: var(--wr-color-dark-contrast);
   border-radius: var(--wr-border-radius-sm);
   font-family: var(--wr-font-family-base);
-  font-size: 0.75rem;
+  font-size: var(--wr-text-xs);
   line-height: 1rem;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
   animation: wr-overlay-in var(--wr-overlay-duration) var(--wr-overlay-ease);

--- a/projects/lib/radio/public-api.ts
+++ b/projects/lib/radio/public-api.ts
@@ -1,3 +1,4 @@
 export { WrRadio } from './radio';
+export type { WrRadioSize } from './radio';
 export { WrRadioGroup } from './radio-group';
 export { WR_RADIO_GROUP, type WrRadioGroupContext } from './tokens';

--- a/projects/lib/radio/radio.ts
+++ b/projects/lib/radio/radio.ts
@@ -26,6 +26,8 @@ import { WR_RADIO_GROUP } from './tokens';
  *
  * @see https://ngwr.dev/components/radio
  */
+export type WrRadioSize = 'sm' | 'md' | 'lg';
+
 @Component({
   selector: 'wr-radio',
   templateUrl: './radio.html',
@@ -46,6 +48,9 @@ export class WrRadio {
    */
   readonly icon = input<WrIconName | null>(null);
 
+  /** Control size — shares the `--wr-control-*` contract. @default 'md' */
+  readonly size = input<WrRadioSize>('md');
+
   private readonly group = inject(WR_RADIO_GROUP, { optional: true });
 
   constructor() {
@@ -60,6 +65,8 @@ export class WrRadio {
 
   protected readonly classes = computed(() => {
     const parts = ['wr-radio'];
+    const size = this.size();
+    if (size !== 'md') parts.push(`wr-radio--${size}`);
     if (this.checked()) parts.push('wr-radio--checked');
     if (this.disabled()) parts.push('wr-radio--disabled');
     if (this.icon()) parts.push('wr-radio--has-icon');

--- a/projects/lib/radio/styles/_index.scss
+++ b/projects/lib/radio/styles/_index.scss
@@ -1,7 +1,9 @@
 @use '../../theme/styles' as theme;
 
 .wr-radio {
-  --wr-radio-size: 1.125rem;
+  --wr-radio-size: 1.125rem; // md (18px)
+  --wr-radio-font-size: var(--wr-text-sm);
+  --wr-radio-line-height: var(--wr-control-line-height-md);
   --wr-radio-bg: var(--wr-color-white);
   --wr-radio-border: var(--wr-color-light);
   --wr-radio-dot: transparent;
@@ -11,8 +13,8 @@
   vertical-align: middle;
   color: var(--wr-radio-color);
   font-family: var(--wr-font-family-base);
-  font-size: 0.875rem;
-  line-height: 1.25rem;
+  font-size: var(--wr-radio-font-size);
+  line-height: var(--wr-radio-line-height);
 
   &__label {
     display: inline-flex;
@@ -52,8 +54,8 @@
 
     &::after {
       content: '';
-      width: 0.5rem;
-      height: 0.5rem;
+      width: calc(var(--wr-radio-size) - 0.625rem);
+      height: calc(var(--wr-radio-size) - 0.625rem);
       border-radius: 50%;
       background: var(--wr-radio-dot);
       transform: scale(0);
@@ -73,6 +75,19 @@
     transition:
       transform var(--wr-transition-base),
       opacity var(--wr-transition-base);
+  }
+
+  // Sizes — dot, label font + line-height scale together.
+  &--sm {
+    --wr-radio-size: 1rem; // 16px
+    --wr-radio-font-size: var(--wr-text-xs);
+    --wr-radio-line-height: var(--wr-control-line-height-sm);
+  }
+
+  &--lg {
+    --wr-radio-size: 1.25rem; // 20px
+    --wr-radio-font-size: var(--wr-text-base);
+    --wr-radio-line-height: var(--wr-control-line-height-lg);
   }
 
   &--has-icon &__dot::after {

--- a/projects/lib/rating/public-api.ts
+++ b/projects/lib/rating/public-api.ts
@@ -1,1 +1,2 @@
 export { WrRating } from './rating';
+export type { WrRatingSize } from './rating';

--- a/projects/lib/rating/rating.html
+++ b/projects/lib/rating/rating.html
@@ -37,6 +37,9 @@
         <path
           d="M12 2.5l2.95 5.98 6.6.96-4.78 4.66 1.13 6.58L12 17.6l-5.9 3.08 1.13-6.58L2.45 9.44l6.6-.96L12 2.5z"
           fill="currentColor"
+          stroke="currentColor"
+          stroke-width="1.4"
+          stroke-linejoin="round"
         />
       </svg>
     </span>

--- a/projects/lib/rating/rating.ts
+++ b/projects/lib/rating/rating.ts
@@ -28,6 +28,8 @@ import { clamp, noop } from 'ngwr/utils';
  *
  * @see https://ngwr.dev/components/rating
  */
+export type WrRatingSize = 'sm' | 'md' | 'lg';
+
 @Component({
   selector: 'wr-rating',
   templateUrl: './rating.html',
@@ -57,6 +59,9 @@ export class WrRating implements ControlValueAccessor {
   /** Disable interaction. @default false */
   readonly disabled = input(false, { transform: coerceBooleanProperty });
 
+  /** Control size — scales the icons + gaps. @default 'md' */
+  readonly size = input<WrRatingSize>('md');
+
   /** Accessible label. @default 'Rating' */
   readonly ariaLabel = input<string>('Rating');
 
@@ -79,6 +84,8 @@ export class WrRating implements ControlValueAccessor {
 
   protected readonly classes = computed(() => {
     const parts = ['wr-rating'];
+    const size = this.size();
+    if (size !== 'md') parts.push(`wr-rating--${size}`);
     if (this.readonly()) parts.push('wr-rating--readonly');
     if (this.effectiveDisabled()) parts.push('wr-rating--disabled');
     return parts.join(' ');

--- a/projects/lib/rating/styles/_index.scss
+++ b/projects/lib/rating/styles/_index.scss
@@ -49,6 +49,17 @@
     transition: clip-path var(--wr-transition-base);
   }
 
+  // Sizes — scale the icon glyph + the gap between slots.
+  &--sm {
+    --wr-rating-size: 1rem; // 16px
+    --wr-rating-gap: 0.0625rem;
+  }
+
+  &--lg {
+    --wr-rating-size: 1.5rem; // 24px
+    --wr-rating-gap: 0.1875rem;
+  }
+
   &--readonly &__slot {
     cursor: default;
   }

--- a/projects/lib/segmented/public-api.ts
+++ b/projects/lib/segmented/public-api.ts
@@ -1,2 +1,3 @@
 export { WrSegmented } from './segmented';
 export type { WrSegmentedOption } from './interfaces';
+export type { WrSegmentedSize } from './segmented';

--- a/projects/lib/segmented/segmented.ts
+++ b/projects/lib/segmented/segmented.ts
@@ -30,6 +30,8 @@ import type { WrSegmentedOption } from './interfaces';
  *
  * @see https://ngwr.dev/components/segmented
  */
+export type WrSegmentedSize = 'sm' | 'md' | 'lg';
+
 @Component({
   selector: 'wr-segmented',
   templateUrl: './segmented.html',
@@ -47,6 +49,9 @@ export class WrSegmented<T = unknown> {
   /** Disable the whole control. @default false */
   readonly disabled = input(false, { transform: coerceBooleanProperty });
 
+  /** Control size — shares the `--wr-control-*` contract. @default 'md' */
+  readonly size = input<WrSegmentedSize>('md');
+
   /** Index of the selected option, or `-1` when nothing is selected. */
   protected readonly selectedIndex = computed(() => {
     const v = this.value();
@@ -62,6 +67,8 @@ export class WrSegmented<T = unknown> {
 
   protected readonly classes = computed(() => {
     const parts = ['wr-segmented'];
+    const size = this.size();
+    if (size !== 'md') parts.push(`wr-segmented--${size}`);
     if (this.disabled()) parts.push('wr-segmented--disabled');
     if (this.selectedIndex() < 0) parts.push('wr-segmented--unselected');
     if (this.mounted()) parts.push('wr-segmented--mounted');

--- a/projects/lib/segmented/styles/_index.scss
+++ b/projects/lib/segmented/styles/_index.scss
@@ -5,7 +5,7 @@
   --wr-segmented-color: var(--wr-color-dark);
   --wr-segmented-selected-bg: var(--wr-color-white);
   --wr-segmented-selected-color: var(--wr-color-dark);
-  --wr-segmented-radius: var(--wr-border-radius-base);
+  --wr-segmented-radius: var(--wr-control-radius-md);
   --wr-segmented-padding: 0.1875rem;
 
   --wr-segmented-thumb-index: 0;
@@ -31,7 +31,7 @@
     width: calc((100% - 2 * var(--wr-segmented-padding)) / var(--wr-segmented-thumb-count));
     transform: translateX(calc(100% * var(--wr-segmented-thumb-index)));
     background: var(--wr-segmented-selected-bg);
-    @include theme.smooth-br(calc(var(--wr-segmented-radius) - var(--wr-segmented-padding)));
+    @include theme.smooth-br(var(--wr-control-radius-sm));
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
     pointer-events: none;
     // Animate slides, but only after first paint — see `&--mounted` below.
@@ -56,8 +56,10 @@
     appearance: none;
     background: transparent;
     border: 0;
-    padding: 0.3125rem 0.75rem;
-    @include theme.smooth-br(calc(var(--wr-segmented-radius) - var(--wr-segmented-padding)));
+    // 2px option padding-y + 2×3px track padding + 20px line-height = 30px,
+    // matching the md control contract (button/input/select).
+    padding: 0.125rem 0.75rem;
+    @include theme.smooth-br(var(--wr-control-radius-sm));
     color: var(--wr-segmented-color);
     font: inherit;
     cursor: pointer;

--- a/projects/lib/segmented/styles/_index.scss
+++ b/projects/lib/segmented/styles/_index.scss
@@ -5,8 +5,13 @@
   --wr-segmented-color: var(--wr-color-dark);
   --wr-segmented-selected-bg: var(--wr-color-white);
   --wr-segmented-selected-color: var(--wr-color-dark);
-  --wr-segmented-radius: var(--wr-control-radius-md);
+  --wr-segmented-radius: 0.5rem; // 8px track
+  // Concentric thumb: outer − inset, so track and thumb corners nest naturally.
+  --wr-segmented-thumb-radius: calc(var(--wr-segmented-radius) - var(--wr-segmented-padding));
   --wr-segmented-padding: 0.1875rem;
+  --wr-segmented-font-size: var(--wr-text-sm);
+  --wr-segmented-line-height: var(--wr-control-line-height-md);
+  --wr-segmented-option-py: 0.125rem;
 
   --wr-segmented-thumb-index: 0;
   --wr-segmented-thumb-count: 1;
@@ -20,8 +25,25 @@
   padding: var(--wr-segmented-padding);
   @include theme.smooth-br(var(--wr-segmented-radius));
   font-family: var(--wr-font-family-base);
-  font-size: 0.8125rem;
-  line-height: 1.25rem;
+  font-size: var(--wr-segmented-font-size);
+  line-height: var(--wr-segmented-line-height);
+
+  // Sizes — track 22 / 30 / 36 px (line-height + 2×option-py + 2×track-padding).
+  &--sm {
+    --wr-segmented-radius: 0.4375rem; // 7px → concentric 5px thumb
+    --wr-segmented-padding: 0.125rem; // 2px
+    --wr-segmented-font-size: var(--wr-text-xs);
+    --wr-segmented-line-height: var(--wr-control-line-height-sm);
+    --wr-segmented-option-py: 0.0625rem; // 1px
+  }
+
+  &--lg {
+    --wr-segmented-radius: 0.5625rem; // 9px → concentric 6px thumb
+    --wr-segmented-padding: 0.1875rem; // 3px
+    --wr-segmented-font-size: var(--wr-text-base);
+    --wr-segmented-line-height: var(--wr-control-line-height-lg);
+    --wr-segmented-option-py: 0.1875rem; // 3px
+  }
 
   &__thumb {
     position: absolute;
@@ -31,7 +53,7 @@
     width: calc((100% - 2 * var(--wr-segmented-padding)) / var(--wr-segmented-thumb-count));
     transform: translateX(calc(100% * var(--wr-segmented-thumb-index)));
     background: var(--wr-segmented-selected-bg);
-    @include theme.smooth-br(var(--wr-control-radius-sm));
+    @include theme.smooth-br(var(--wr-segmented-thumb-radius));
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
     pointer-events: none;
     // Animate slides, but only after first paint — see `&--mounted` below.
@@ -56,10 +78,9 @@
     appearance: none;
     background: transparent;
     border: 0;
-    // 2px option padding-y + 2×3px track padding + 20px line-height = 30px,
-    // matching the md control contract (button/input/select).
-    padding: 0.125rem 0.75rem;
-    @include theme.smooth-br(var(--wr-control-radius-sm));
+    // Height = line-height + 2×option-py + 2×track-padding (md → 30px); all scale per size.
+    padding: var(--wr-segmented-option-py) 0.75rem;
+    @include theme.smooth-br(var(--wr-segmented-thumb-radius));
     color: var(--wr-segmented-color);
     font: inherit;
     cursor: pointer;
@@ -84,7 +105,7 @@
   }
 
   &__label {
-    line-height: 1.25rem;
+    line-height: var(--wr-segmented-line-height);
   }
 
   &--disabled {

--- a/projects/lib/select/interfaces/index.ts
+++ b/projects/lib/select/interfaces/index.ts
@@ -36,3 +36,6 @@ export type WrSelectTagValidator = (value: string, existing: readonly string[]) 
 export type WrSelectSearchLoader<T> = (
   query: string
 ) => Observable<readonly T[]> | Promise<readonly T[]> | readonly T[];
+
+/** Control size for `<wr-select>` — shares the `--wr-control-*` contract. */
+export type WrSelectSize = 'sm' | 'md' | 'lg';

--- a/projects/lib/select/public-api.ts
+++ b/projects/lib/select/public-api.ts
@@ -2,4 +2,4 @@ export { WrSelect } from './select';
 export { WrOption } from './option';
 export { WrOptionGroup } from './option-group';
 export { WR_SELECT, type WrSelectContext } from './tokens';
-export type { WrSelectMode, WrSelectSearchLoader, WrSelectTagValidator } from './interfaces';
+export type { WrSelectMode, WrSelectSearchLoader, WrSelectTagValidator, WrSelectSize } from './interfaces';

--- a/projects/lib/select/select.html
+++ b/projects/lib/select/select.html
@@ -255,6 +255,8 @@
 <ng-template #panelTpl>
   <div
     class="wr-select-panel"
+    [class.wr-select-panel--sm]="size() === 'sm'"
+    [class.wr-select-panel--lg]="size() === 'lg'"
     role="listbox"
     [attr.id]="listboxId"
     [attr.aria-multiselectable]="isMulti() ? 'true' : null"

--- a/projects/lib/select/select.ts
+++ b/projects/lib/select/select.ts
@@ -32,7 +32,7 @@ import { useI18nFormatter, useI18nText } from 'ngwr/i18n';
 import { WR_OVERLAY, WR_RESPONSIVE_OVERLAYS, wrPresentAsSheet } from 'ngwr/overlay';
 import { noop } from 'ngwr/utils';
 
-import type { WrSelectMode, WrSelectSearchLoader, WrSelectTagValidator } from './interfaces';
+import type { WrSelectMode, WrSelectSearchLoader, WrSelectTagValidator, WrSelectSize } from './interfaces';
 import { WrOption } from './option';
 import { WR_SELECT, type WrSelectContext, type WrSelectOptionRegistration } from './tokens';
 
@@ -119,6 +119,9 @@ export class WrSelect implements ControlValueAccessor, WrSelectContext {
 
   /** Pill-shaped corners on the trigger. @default false */
   readonly rounded = input(false, { transform: coerceBooleanProperty });
+
+  /** Control size — shares the `--wr-control-*` contract. @default 'md' */
+  readonly size = input<WrSelectSize>('md');
 
   /**
    * Present the option panel as a full-width bottom-sheet on small
@@ -330,6 +333,8 @@ export class WrSelect implements ControlValueAccessor, WrSelectContext {
     const parts = ['wr-select'];
     if (this.open()) parts.push('wr-select--open');
     if (this.rounded()) parts.push('wr-select--rounded');
+    const size = this.size();
+    if (size !== 'md') parts.push(`wr-select--${size}`);
     if (this.isMulti()) parts.push('wr-select--multi');
     if (this.isTag()) parts.push('wr-select--tag');
     if (this.isSearch()) parts.push('wr-select--search');
@@ -799,7 +804,14 @@ export class WrSelect implements ControlValueAccessor, WrSelectContext {
     this.overlayRef = this.overlay.create({
       positionStrategy,
       scrollStrategy: asSheet ? this.scrollStrategies.block() : this.scrollStrategies.reposition(),
-      width: asSheet ? '100%' : this.host.nativeElement.getBoundingClientRect().width,
+      // Floor the panel at the trigger width (it can still grow for long
+      // options) instead of pinning it. The panel fills this via `width: 100%`,
+      // so the flex overlay pane has no transparent gutter beside a
+      // content-narrow panel — that gutter would otherwise sit "inside" the
+      // overlay and swallow outside-clicks, leaving the panel open. Mirrors how
+      // mat-select sizes its overlay.
+      width: asSheet ? '100%' : undefined,
+      minWidth: asSheet ? undefined : this.host.nativeElement.getBoundingClientRect().width,
       hasBackdrop: asSheet,
       backdropClass: asSheet ? 'wr-select-backdrop' : undefined,
       panelClass: asSheet ? ['wr-select-overlay', 'wr-overlay-sheet'] : 'wr-select-overlay',

--- a/projects/lib/select/styles/_index.scss
+++ b/projects/lib/select/styles/_index.scss
@@ -200,7 +200,7 @@
     border-radius: 999px;
     background: rgba(var(--wr-color-primary-rgb), 0.1);
     color: var(--wr-color-primary);
-    font-size: 0.8125rem;
+    font-size: var(--wr-text-sm);
     line-height: 1.4;
     user-select: none;
   }
@@ -359,7 +359,7 @@
   &__label {
     padding: 0.5rem 0.625rem 0.25rem;
     color: var(--wr-color-medium);
-    font-size: 0.6875rem;
+    font-size: var(--wr-text-xs);
     font-weight: 600;
     letter-spacing: 0.04em;
     text-transform: uppercase;

--- a/projects/lib/select/styles/_index.scss
+++ b/projects/lib/select/styles/_index.scss
@@ -5,14 +5,33 @@
   --wr-select-color: var(--wr-color-dark);
   --wr-select-bg: var(--wr-color-white);
   --wr-select-border: var(--wr-color-light);
-  --wr-select-radius: var(--wr-border-radius-base);
-  --wr-select-padding-y: 0.4375rem;
-  --wr-select-padding-x: 0.75rem;
-  --wr-select-font-size: 0.875rem;
-  --wr-select-line-height: 1.25rem;
+  --wr-select-radius: var(--wr-control-radius-md);
+  --wr-select-padding-y: var(--wr-control-padding-y-md);
+  --wr-select-padding-x: var(--wr-control-padding-x-md);
+  --wr-select-font-size: var(--wr-control-font-size-md);
+  --wr-select-line-height: var(--wr-control-line-height-md);
 
   display: inline-flex;
   vertical-align: middle;
+
+  // Sizes — share the `--wr-control-*` contract (22 / 30 / 36 px). Multi/tag
+  // min-height and the search/tag inputs all read these vars, so every mode
+  // tracks the size. Declared before `--rounded` so the pill modifier wins.
+  &--sm {
+    --wr-select-radius: var(--wr-control-radius-sm);
+    --wr-select-padding-y: var(--wr-control-padding-y-sm);
+    --wr-select-padding-x: var(--wr-control-padding-x-sm);
+    --wr-select-font-size: var(--wr-control-font-size-sm);
+    --wr-select-line-height: var(--wr-control-line-height-sm);
+  }
+
+  &--lg {
+    --wr-select-radius: var(--wr-control-radius-lg);
+    --wr-select-padding-y: var(--wr-control-padding-y-lg);
+    --wr-select-padding-x: var(--wr-control-padding-x-lg);
+    --wr-select-font-size: var(--wr-control-font-size-lg);
+    --wr-select-line-height: var(--wr-control-line-height-lg);
+  }
 
   &--rounded {
     --wr-select-radius: var(--wr-border-radius-pill);
@@ -94,8 +113,10 @@
   &--tag &__trigger {
     flex-wrap: wrap;
     align-items: center;
-    padding: 0.25rem 0.5rem;
-    min-height: calc(var(--wr-select-line-height) + var(--wr-select-padding-y) * 2);
+    padding: calc(var(--wr-select-padding-y) * var(--wr-density-y, 1)) calc(var(--wr-select-padding-x) * var(--wr-density-x, 1));
+    // Empty / single chip-row floor = single-mode height
+    // (line-height + 2×padding-y + 2×1px border), so every size + density lines up.
+    min-height: calc(var(--wr-select-line-height) + var(--wr-select-padding-y) * var(--wr-density-y, 1) * 2 + 2px);
   }
 
   // Search-mode trigger: inline text input + chevron + clear
@@ -114,7 +135,7 @@
     min-width: 0;
     border: 0;
     outline: 0;
-    padding: var(--wr-select-padding-y) var(--wr-select-padding-x);
+    padding: calc(var(--wr-select-padding-y) * var(--wr-density-y, 1)) calc(var(--wr-select-padding-x) * var(--wr-density-x, 1));
     background: transparent;
     color: inherit;
     font: inherit;
@@ -149,8 +170,8 @@
     background: transparent;
     color: inherit;
     font: inherit;
-    font-size: 0.875rem;
-    line-height: 1.4;
+    font-size: var(--wr-select-font-size);
+    line-height: var(--wr-select-line-height);
 
     &::placeholder {
       color: rgba(var(--wr-color-medium-rgb), 0.85);
@@ -243,9 +264,20 @@
   --wr-select-panel-radius: var(--wr-border-radius-base);
   --wr-select-panel-shadow: var(--wr-shadow-overlay);
   --wr-select-panel-max-height: 16rem;
+  // Option sizing — default md. --sm/--lg are set from the trigger size because
+  // the panel is portaled into an overlay and can't inherit the host size class.
+  --wr-option-font-size: var(--wr-control-font-size-md);
+  --wr-option-line-height: var(--wr-control-line-height-md);
+  --wr-option-padding-y: 0.4375rem;
+  --wr-option-padding-x: 0.625rem;
+  --wr-option-gap: 0.1875rem;
 
   display: flex;
   flex-direction: column;
+  // Fill the overlay pane so the visible panel == the pointer-catching surface;
+  // no transparent gutter to swallow outside-clicks (see openOverlay in select.ts).
+  width: 100%;
+  gap: var(--wr-option-gap);
   background: var(--wr-select-panel-bg);
   border: 1px solid var(--wr-select-panel-border);
   @include theme.smooth-br(var(--wr-select-panel-radius));
@@ -255,11 +287,27 @@
   overflow-y: auto;
   font-family: var(--wr-font-family-base);
 
+  &--sm {
+    --wr-option-font-size: var(--wr-control-font-size-sm);
+    --wr-option-line-height: var(--wr-control-line-height-sm);
+    --wr-option-padding-y: 0.3125rem;
+    --wr-option-padding-x: 0.5rem;
+    --wr-option-gap: 0.125rem;
+  }
+
+  &--lg {
+    --wr-option-font-size: var(--wr-control-font-size-lg);
+    --wr-option-line-height: var(--wr-control-line-height-lg);
+    --wr-option-padding-y: 0.5rem;
+    --wr-option-padding-x: 0.75rem;
+    --wr-option-gap: 0.25rem;
+  }
+
   &__loading,
   &__empty {
     padding: 0.625rem 0.75rem;
     color: var(--wr-color-medium);
-    font-size: 0.875rem;
+    font-size: var(--wr-option-font-size);
     text-align: center;
   }
 }
@@ -267,11 +315,11 @@
 .wr-option {
   display: flex;
   align-items: center;
-  padding: 0.4375rem 0.625rem;
+  padding: var(--wr-option-padding-y) var(--wr-option-padding-x);
   border-radius: var(--wr-border-radius-sm);
   color: var(--wr-color-dark);
-  font-size: 0.875rem;
-  line-height: 1.25rem;
+  font-size: var(--wr-option-font-size);
+  line-height: var(--wr-option-line-height);
   cursor: pointer;
   user-select: none;
   transition: background var(--wr-transition-short);
@@ -306,6 +354,7 @@
 .wr-option-group {
   display: flex;
   flex-direction: column;
+  gap: var(--wr-option-gap);
 
   &__label {
     padding: 0.5rem 0.625rem 0.25rem;

--- a/projects/lib/slider/styles/_index.scss
+++ b/projects/lib/slider/styles/_index.scss
@@ -66,7 +66,7 @@
   &__label {
     margin-top: 0.5rem;
     color: var(--wr-slider-label);
-    font-size: 0.8125rem;
+    font-size: var(--wr-text-sm);
     line-height: 1.125rem;
     font-variant-numeric: tabular-nums;
   }

--- a/projects/lib/splitter/styles/_index.scss
+++ b/projects/lib/splitter/styles/_index.scss
@@ -69,13 +69,13 @@
   &--horizontal &__handle {
     width: 0.875rem;
     height: 2rem;
-    @include theme.smooth-br(4px);
+    @include theme.smooth-br(var(--wr-control-radius-sm));
   }
 
   &--vertical &__handle {
     width: 2rem;
     height: 0.875rem;
-    @include theme.smooth-br(4px);
+    @include theme.smooth-br(var(--wr-control-radius-sm));
   }
 
   &--disabled &__divider {

--- a/projects/lib/stepper/styles/_index.scss
+++ b/projects/lib/stepper/styles/_index.scss
@@ -80,7 +80,7 @@
     border: 1.5px solid var(--wr-color-light);
     background: var(--wr-color-white);
     color: var(--wr-stepper-muted);
-    font-size: 0.8125rem;
+    font-size: var(--wr-text-sm);
     font-weight: 600;
     display: inline-flex;
     align-items: center;
@@ -108,7 +108,7 @@
     display: inline-flex;
     flex-direction: column;
     gap: 0.0625rem;
-    font-size: 0.875rem;
+    font-size: var(--wr-text-sm);
     font-weight: 500;
     line-height: 1.25rem;
   }
@@ -119,7 +119,7 @@
 
   &__optional,
   &__description {
-    font-size: 0.6875rem;
+    font-size: var(--wr-text-xs);
     font-weight: 500;
     color: var(--wr-stepper-muted);
     text-transform: none;

--- a/projects/lib/switch/public-api.ts
+++ b/projects/lib/switch/public-api.ts
@@ -1,1 +1,2 @@
 export { WrSwitch } from './switch';
+export type { WrSwitchSize } from './switch';

--- a/projects/lib/switch/styles/_index.scss
+++ b/projects/lib/switch/styles/_index.scss
@@ -1,9 +1,11 @@
 @use '../../theme/styles' as theme;
 
 .wr-switch {
-  --wr-switch-track-width: 2.25rem;
-  --wr-switch-track-height: 1.25rem;
-  --wr-switch-thumb-size: 1rem;
+  --wr-switch-track-width: 2rem;
+  --wr-switch-track-height: 1.125rem; // md = checkbox/radio box (18px)
+  --wr-switch-thumb-size: 0.875rem;
+  --wr-switch-font-size: var(--wr-text-sm);
+  --wr-switch-line-height: var(--wr-control-line-height-md);
   --wr-switch-bg: var(--wr-color-light);
   --wr-switch-bg-checked: var(--wr-color-primary);
   --wr-switch-thumb: var(--wr-color-white);
@@ -13,8 +15,8 @@
   vertical-align: middle;
   color: var(--wr-switch-color);
   font-family: var(--wr-font-family-base);
-  font-size: 0.875rem;
-  line-height: 1.25rem;
+  font-size: var(--wr-switch-font-size);
+  line-height: var(--wr-switch-line-height);
 
   &__label {
     display: inline-flex;
@@ -61,6 +63,23 @@
     border-radius: 50%;
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
     transition: left var(--wr-transition-base);
+  }
+
+  // Sizes — track, thumb, label font + line-height scale together.
+  &--sm {
+    --wr-switch-track-width: 1.75rem;
+    --wr-switch-track-height: 1rem;
+    --wr-switch-thumb-size: 0.75rem;
+    --wr-switch-font-size: var(--wr-text-xs);
+    --wr-switch-line-height: var(--wr-control-line-height-sm);
+  }
+
+  &--lg {
+    --wr-switch-track-width: 2.375rem;
+    --wr-switch-track-height: 1.25rem;
+    --wr-switch-thumb-size: 1rem;
+    --wr-switch-font-size: var(--wr-text-base);
+    --wr-switch-line-height: var(--wr-control-line-height-lg);
   }
 
   &--checked {

--- a/projects/lib/switch/switch.ts
+++ b/projects/lib/switch/switch.ts
@@ -21,6 +21,8 @@ import { noop, randomId } from 'ngwr/utils';
  *
  * @see https://ngwr.dev/components/switch
  */
+export type WrSwitchSize = 'sm' | 'md' | 'lg';
+
 @Component({
   selector: 'wr-switch',
   templateUrl: './switch.html',
@@ -46,6 +48,9 @@ export class WrSwitch implements ControlValueAccessor {
    */
   readonly disabled = input(false, { transform: coerceBooleanProperty });
 
+  /** Control size — shares the `--wr-control-*` contract. @default 'md' */
+  readonly size = input<WrSwitchSize>('md');
+
   protected readonly checked = signal(false);
   private readonly disabledFromCva = signal(false);
 
@@ -53,6 +58,8 @@ export class WrSwitch implements ControlValueAccessor {
 
   protected readonly classes = computed(() => {
     const parts = ['wr-switch'];
+    const size = this.size();
+    if (size !== 'md') parts.push(`wr-switch--${size}`);
     if (this.checked()) parts.push('wr-switch--checked');
     if (this.effectiveDisabled()) parts.push('wr-switch--disabled');
     return parts.join(' ');

--- a/projects/lib/table/styles/_index.scss
+++ b/projects/lib/table/styles/_index.scss
@@ -29,7 +29,7 @@
   &__table {
     width: 100%;
     border-collapse: collapse;
-    font-size: 0.875rem;
+    font-size: var(--wr-text-sm);
     line-height: 1.25rem;
   }
 
@@ -45,7 +45,7 @@
     background: var(--wr-table-head-bg);
     color: var(--wr-color-medium);
     font-weight: 600;
-    font-size: 0.6875rem;
+    font-size: var(--wr-text-xs);
     letter-spacing: 0.04em;
     text-transform: uppercase;
     white-space: nowrap;
@@ -154,7 +154,7 @@
     content: attr(data-label);
     flex: 0 0 auto;
     color: var(--wr-color-medium);
-    font-size: 0.6875rem;
+    font-size: var(--wr-text-xs);
     font-weight: 600;
     letter-spacing: 0.04em;
     text-transform: uppercase;
@@ -214,7 +214,7 @@
     border-radius: var(--wr-border-radius-pill);
     background: var(--wr-color-primary);
     color: var(--wr-color-primary-contrast);
-    font-size: 0.625rem;
+    font-size: 0.625rem; // 10px — intentional micro-count badge, below --wr-text-xs
     font-weight: 600;
   }
 
@@ -237,7 +237,7 @@
     background: transparent;
     color: var(--wr-color-dark);
     font: inherit;
-    font-size: 0.8125rem;
+    font-size: var(--wr-text-sm);
   }
 
   &__list {
@@ -258,7 +258,7 @@
     border-radius: var(--wr-border-radius-sm);
     color: var(--wr-color-dark);
     font: inherit;
-    font-size: 0.8125rem;
+    font-size: var(--wr-text-sm);
     text-align: left;
     cursor: pointer;
 
@@ -293,7 +293,7 @@
   &__empty {
     padding: 0.625rem 0.5rem;
     color: var(--wr-color-medium);
-    font-size: 0.8125rem;
+    font-size: var(--wr-text-sm);
     text-align: center;
   }
 
@@ -305,7 +305,7 @@
     border-radius: var(--wr-border-radius-sm);
     color: var(--wr-color-primary);
     font: inherit;
-    font-size: 0.8125rem;
+    font-size: var(--wr-text-sm);
     cursor: pointer;
     text-align: left;
 

--- a/projects/lib/tabs/styles/_index.scss
+++ b/projects/lib/tabs/styles/_index.scss
@@ -6,6 +6,10 @@
   --wr-tabs-color-hover: var(--wr-color-dark);
   --wr-tabs-color-active: var(--wr-color-primary);
   --wr-tabs-indicator: var(--wr-color-primary);
+  --wr-tabs-font-size: var(--wr-control-font-size-md);
+  --wr-tabs-line-height: var(--wr-control-line-height-md);
+  --wr-tabs-padding-y: 0.625rem;
+  --wr-tabs-padding-x: 1rem;
 
   display: block;
   // Claim the full row even when nested in a flex-row demo wrapper.
@@ -13,6 +17,21 @@
   width: 100%;
   min-width: 0;
   font-family: var(--wr-font-family-base);
+
+  // Sizes — wire the (previously inert) `size` input to the control fonts.
+  &--sm {
+    --wr-tabs-font-size: var(--wr-control-font-size-sm);
+    --wr-tabs-line-height: var(--wr-control-line-height-sm);
+    --wr-tabs-padding-y: 0.5rem;
+    --wr-tabs-padding-x: 0.75rem;
+  }
+
+  &--lg {
+    --wr-tabs-font-size: var(--wr-control-font-size-lg);
+    --wr-tabs-line-height: var(--wr-control-line-height-lg);
+    --wr-tabs-padding-y: 0.75rem;
+    --wr-tabs-padding-x: 1.25rem;
+  }
 
   &__strip {
     display: flex;
@@ -60,12 +79,12 @@
     background: transparent;
     border: 0;
     text-decoration: none;
-    padding: 0.625rem 1rem;
+    padding: var(--wr-tabs-padding-y) var(--wr-tabs-padding-x);
     color: var(--wr-tabs-color);
     font: inherit;
-    font-size: 0.875rem;
+    font-size: var(--wr-tabs-font-size);
     font-weight: 500;
-    line-height: 1.25rem;
+    line-height: var(--wr-tabs-line-height);
     border-bottom: 2px solid transparent;
     cursor: pointer;
     white-space: nowrap;

--- a/projects/lib/tabs/tabs.ts
+++ b/projects/lib/tabs/tabs.ts
@@ -62,6 +62,8 @@ import { WR_TABS, type WrTabsContext } from './tokens';
     class: 'wr-tabs',
     '[class.wr-tabs--fade-start]': 'canScrollStart()',
     '[class.wr-tabs--fade-end]': 'canScrollEnd()',
+    '[class.wr-tabs--sm]': "size() === 'sm'",
+    '[class.wr-tabs--lg]': "size() === 'lg'",
   },
   imports: [NgTemplateOutlet, RouterLink, RouterLinkActive],
   providers: [

--- a/projects/lib/textarea/public-api.ts
+++ b/projects/lib/textarea/public-api.ts
@@ -1,1 +1,2 @@
 export { WrTextarea } from './textarea';
+export type { WrTextareaSize, WrTextareaResize } from './textarea';

--- a/projects/lib/textarea/styles/_index.scss
+++ b/projects/lib/textarea/styles/_index.scss
@@ -9,11 +9,11 @@
   --wr-textarea-placeholder: rgba(var(--wr-color-medium-rgb), 0.7);
   --wr-textarea-bg: var(--wr-color-white);
   --wr-textarea-border: var(--wr-color-light);
-  --wr-textarea-radius: var(--wr-border-radius-base);
+  --wr-textarea-radius: var(--wr-control-radius-md);
   --wr-textarea-ring: transparent;
   --wr-textarea-padding-y: 0.5rem;
-  --wr-textarea-padding-x: 0.75rem;
-  --wr-textarea-font-size: 0.875rem;
+  --wr-textarea-padding-x: var(--wr-control-padding-x-md);
+  --wr-textarea-font-size: var(--wr-text-sm);
   --wr-textarea-line-height: 1.375rem;
 
   background: var(--wr-textarea-bg);
@@ -37,6 +37,29 @@
     cursor: not-allowed;
   }
 
+  // Horizontal resize needs a shrinkable, explicit-width box (not full-width block).
+  &--resize-x {
+    display: inline-block;
+    max-width: 100%;
+  }
+
+  // Sizes — radius, padding, font + line-height scale; height stays content-driven.
+  &--sm {
+    --wr-textarea-radius: var(--wr-control-radius-sm);
+    --wr-textarea-padding-y: 0.375rem;
+    --wr-textarea-padding-x: var(--wr-control-padding-x-sm);
+    --wr-textarea-font-size: var(--wr-text-xs);
+    --wr-textarea-line-height: 1.125rem;
+  }
+
+  &--lg {
+    --wr-textarea-radius: var(--wr-control-radius-lg);
+    --wr-textarea-padding-y: 0.625rem;
+    --wr-textarea-padding-x: var(--wr-control-padding-x-lg);
+    --wr-textarea-font-size: var(--wr-text-base);
+    --wr-textarea-line-height: 1.625rem;
+  }
+
   &--no-resize &__native {
     resize: none;
   }
@@ -55,7 +78,8 @@
     line-height: var(--wr-textarea-line-height);
     padding: calc(var(--wr-textarea-padding-y) * var(--wr-density-y, 1))
       calc(var(--wr-textarea-padding-x) * var(--wr-density-x, 1));
-    resize: vertical;
+    // Native grip removed — we draw our own corner grip (&__resize) instead.
+    resize: none;
 
     &::placeholder {
       color: var(--wr-textarea-placeholder);
@@ -63,6 +87,37 @@
 
     &:disabled {
       cursor: not-allowed;
+    }
+  }
+
+  // Corner resize grip — icon (move-vertical / -horizontal / -diagonal-2) and
+  // cursor follow the `resize` direction.
+  &__resize {
+    position: absolute;
+    right: 0.25rem;
+    bottom: 0.25rem;
+    display: inline-flex;
+    color: rgba(var(--wr-color-medium-rgb), 0.55);
+    touch-action: none;
+    transition: color var(--wr-transition-base);
+
+    &--vertical {
+      cursor: ns-resize;
+    }
+    &--horizontal {
+      cursor: ew-resize;
+    }
+    &--both {
+      cursor: nwse-resize;
+    }
+
+    .wr-icon__svg {
+      width: 0.875rem;
+      height: 0.875rem;
+    }
+
+    &:hover {
+      color: var(--wr-color-medium);
     }
   }
 }

--- a/projects/lib/textarea/textarea.html
+++ b/projects/lib/textarea/textarea.html
@@ -10,3 +10,46 @@
   (focus)="focused.set(true)"
   (blur)="onBlur()"
 ></textarea>
+
+@if (showHandle()) {
+  <!-- Custom corner grip — the lucide icon + cursor follow the `resize`
+       direction. Icons inlined so no icon registration is required. -->
+  <span
+    [class]="`wr-textarea__resize wr-textarea__resize--${effectiveResize()}`"
+    aria-hidden="true"
+    (pointerdown)="startResize($event)"
+    (pointermove)="onResize($event)"
+    (pointerup)="endResize($event)"
+    (pointercancel)="endResize($event)"
+  >
+    <svg
+      class="wr-icon__svg"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      @switch (effectiveResize()) {
+        @case ('vertical') {
+          <path d="M12 2v20" />
+          <path d="m8 18 4 4 4-4" />
+          <path d="m8 6 4-4 4 4" />
+        }
+        @case ('horizontal') {
+          <path d="M2 12h20" />
+          <path d="m18 8 4 4-4 4" />
+          <path d="m6 8-4 4 4 4" />
+        }
+        @default {
+          <path d="M19 13v6h-6" />
+          <path d="M5 11V5h6" />
+          <path d="m5 5 14 14" />
+        }
+      }
+    </svg>
+  </span>
+}

--- a/projects/lib/textarea/textarea.ts
+++ b/projects/lib/textarea/textarea.ts
@@ -7,9 +7,9 @@
 
 import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coercion';
 import { isPlatformBrowser } from '@angular/common';
-import type { ElementRef } from '@angular/core';
 import {
   Component,
+  ElementRef,
   PLATFORM_ID,
   ViewEncapsulation,
   computed,
@@ -38,6 +38,10 @@ import { noop } from 'ngwr/utils';
  *
  * @see https://ngwr.dev/components/textarea
  */
+export type WrTextareaSize = 'sm' | 'md' | 'lg';
+
+export type WrTextareaResize = 'none' | 'vertical' | 'horizontal' | 'both';
+
 @Component({
   selector: 'wr-textarea',
   templateUrl: './textarea.html',
@@ -56,11 +60,17 @@ export class WrTextarea implements ControlValueAccessor {
   /** Native placeholder text. @default '' */
   readonly placeholder = input<string>('');
 
+  /** Control size — shares the `--wr-control-*` contract. @default 'md' */
+  readonly size = input<WrTextareaSize>('md');
+
   /** Visible row count. @default 3 */
   readonly rows = input(3, { transform: (v: unknown): number => coerceNumberProperty(v, 3) });
 
-  /** Allow user resize via the native handle. @default true */
+  /** Allow user resize via the corner grip. @default true */
   readonly resizable = input(true, { transform: coerceBooleanProperty });
+
+  /** Resize direction of the corner grip (the grip icon adapts). @default 'vertical' */
+  readonly resize = input<WrTextareaResize>('vertical');
 
   /** Read-only state. @default false */
   readonly readonly = input(false, { transform: coerceBooleanProperty });
@@ -86,19 +96,41 @@ export class WrTextarea implements ControlValueAccessor {
 
   protected readonly native = viewChild.required<ElementRef<HTMLTextAreaElement>>('native');
 
+  /** Resize direction, gated by `resizable` (false → 'none'). */
+  protected readonly effectiveResize = computed<WrTextareaResize>(() => (this.resizable() ? this.resize() : 'none'));
+
   protected readonly classes = computed(() => {
     const parts = ['wr-textarea'];
-    if (!this.resizable() || this.autosize()) parts.push('wr-textarea--no-resize');
+    const size = this.size();
+    if (size !== 'md') parts.push(`wr-textarea--${size}`);
+    if (this.autosize()) parts.push('wr-textarea--no-resize');
+    const resize = this.effectiveResize();
+    if (resize === 'horizontal' || resize === 'both') parts.push('wr-textarea--resize-x');
     if (this.focused()) parts.push('wr-textarea--focused');
     if (this.effectiveDisabled()) parts.push('wr-textarea--disabled');
     return parts.join(' ');
   });
 
+  /** Show the corner grip (hidden when direction is 'none' / autosize / disabled). */
+  protected readonly showHandle = computed(
+    () => this.effectiveResize() !== 'none' && !this.autosize() && !this.effectiveDisabled()
+  );
+
   private readonly platformId = inject(PLATFORM_ID);
   private readonly isBrowser = isPlatformBrowser(this.platformId);
+  private readonly hostEl = inject<ElementRef<HTMLElement>>(ElementRef);
 
   private onChange: (value: string) => void = noop;
   private onTouched: () => void = noop;
+
+  // Custom resize-grip drag state (replaces the native corner handle).
+  private resizing = false;
+  private resizeStartY = 0;
+  private resizeStartX = 0;
+  private resizeStartHeight = 0;
+  private resizeStartWidth = 0;
+  private resizeMinHeight = 36;
+  private resizeMaxWidth = Number.POSITIVE_INFINITY;
 
   constructor() {
     // Autosize: re-fit whenever value or autosize toggles.
@@ -106,7 +138,7 @@ export class WrTextarea implements ControlValueAccessor {
       if (!this.autosize() || !this.isBrowser) return;
       // Read `value` to register dependency
       this.value();
-      requestAnimationFrame(() => this.resize());
+      requestAnimationFrame(() => this.autofit());
     });
   }
 
@@ -141,7 +173,55 @@ export class WrTextarea implements ControlValueAccessor {
     this.onTouched();
   }
 
-  private resize(): void {
+  // Custom resize — drag the corner grip; direction comes from `effectiveResize`.
+  // Pointer capture keeps move/up on the grip even when the cursor leaves it.
+  protected startResize(event: PointerEvent): void {
+    const el = this.native()?.nativeElement;
+    if (!el) return;
+    const host = this.hostEl.nativeElement;
+    this.resizing = true;
+    this.resizeStartY = event.clientY;
+    this.resizeStartX = event.clientX;
+    this.resizeStartHeight = el.offsetHeight;
+    this.resizeStartWidth = host.offsetWidth;
+    // Height floor = fits the current content, so shrinking never opens an
+    // overflow scrollbar. Measured once, synchronously (no paint between).
+    const borderY = el.offsetHeight - el.clientHeight;
+    const prevHeight = el.style.height;
+    el.style.height = 'auto';
+    this.resizeMinHeight = el.scrollHeight + borderY;
+    el.style.height = prevHeight;
+    // Width ceiling = parent inner width, so horizontal drag can't overflow.
+    this.resizeMaxWidth = host.parentElement?.clientWidth ?? Number.POSITIVE_INFINITY;
+    (event.target as HTMLElement).setPointerCapture(event.pointerId);
+    event.preventDefault();
+  }
+
+  protected onResize(event: PointerEvent): void {
+    if (!this.resizing) return;
+    const el = this.native()?.nativeElement;
+    if (!el) return;
+    const dir = this.effectiveResize();
+    if (dir === 'vertical' || dir === 'both') {
+      const h = Math.max(this.resizeMinHeight, this.resizeStartHeight + (event.clientY - this.resizeStartY));
+      el.style.height = `${h}px`;
+    }
+    if (dir === 'horizontal' || dir === 'both') {
+      const w = Math.min(
+        this.resizeMaxWidth,
+        Math.max(64, this.resizeStartWidth + (event.clientX - this.resizeStartX))
+      );
+      this.hostEl.nativeElement.style.width = `${w}px`;
+    }
+  }
+
+  protected endResize(event: PointerEvent): void {
+    if (!this.resizing) return;
+    this.resizing = false;
+    (event.target as HTMLElement).releasePointerCapture(event.pointerId);
+  }
+
+  private autofit(): void {
     const el = this.native()?.nativeElement;
     if (!el) return;
 

--- a/projects/lib/theme/styles/_variables.scss
+++ b/projects/lib/theme/styles/_variables.scss
@@ -10,6 +10,30 @@
   --wr-border-radius-lg: 1rem;
   --wr-border-radius-pill: 50rem;
 
+  // Control sizing
+  //
+  // The shared contract every form control reads (button, input, select, …)
+  // so they line up pixel-for-pixel at each size. Height is NOT fixed — it's
+  // the sum of `line-height + 2×padding-y + 2×border(1px)`, so padding-y can
+  // stay density-aware (`* var(--wr-density-y)`) and controls track density
+  // together. Keep the three parts in sync if you retune a size.
+  //   sm → 22px · md → 30px · lg → 36px   (radius 5 / 6 / 7)
+  --wr-control-padding-y-sm: 0.125rem; // 2px  → 16 + 4 + 2 = 22
+  --wr-control-padding-y-md: 0.25rem; // 4px  → 20 + 8 + 2 = 30
+  --wr-control-padding-y-lg: 0.3125rem; // 5px  → 24 + 10 + 2 = 36
+  --wr-control-padding-x-sm: 0.5rem; // 8px
+  --wr-control-padding-x-md: 0.75rem; // 12px
+  --wr-control-padding-x-lg: 1rem; // 16px
+  --wr-control-line-height-sm: 1rem; // 16px
+  --wr-control-line-height-md: 1.25rem; // 20px
+  --wr-control-line-height-lg: 1.5rem; // 24px
+  --wr-control-font-size-sm: var(--wr-text-xs); // 12px
+  --wr-control-font-size-md: var(--wr-text-sm); // 14px
+  --wr-control-font-size-lg: var(--wr-text-base); // 16px
+  --wr-control-radius-sm: 5px;
+  --wr-control-radius-md: 6px;
+  --wr-control-radius-lg: 7px;
+
   // Easing curves
   --wr-ease-linear: linear;
   --wr-ease-out: cubic-bezier(0.16, 1, 0.3, 1);

--- a/projects/lib/toast/styles/_index.scss
+++ b/projects/lib/toast/styles/_index.scss
@@ -147,7 +147,7 @@ $toast-colors: (
   &__title {
     margin: 0 0 0.125rem;
     color: var(--wr-toast-title);
-    font-size: 0.875rem;
+    font-size: var(--wr-text-sm);
     font-weight: 600;
     line-height: 1.25rem;
   }
@@ -155,7 +155,7 @@ $toast-colors: (
   &__message {
     margin: 0;
     color: var(--wr-toast-message);
-    font-size: 0.8125rem;
+    font-size: var(--wr-text-sm);
     line-height: 1.125rem;
     overflow-wrap: break-word;
   }
@@ -243,7 +243,7 @@ $toast-colors: (
   padding: 0.375rem 0.75rem;
   color: var(--wr-color-medium);
   font-family: var(--wr-font-family-base);
-  font-size: 0.75rem;
+  font-size: var(--wr-text-xs);
   font-weight: 500;
   line-height: 1rem;
   text-align: center;

--- a/projects/lib/tree/styles/_index.scss
+++ b/projects/lib/tree/styles/_index.scss
@@ -100,11 +100,13 @@
     --wr-tree-trigger-color: var(--wr-color-dark);
     --wr-tree-trigger-bg: var(--wr-color-white);
     --wr-tree-trigger-border: var(--wr-color-light);
-    --wr-tree-trigger-radius: var(--wr-border-radius-base);
-    --wr-tree-trigger-padding-y: 0.4375rem;
-    --wr-tree-trigger-padding-x: 0.75rem;
-    --wr-tree-trigger-font-size: 0.875rem;
-    --wr-tree-trigger-line-height: 1.25rem;
+    // Combobox trigger on the md control contract (30px, radius 6) so it lines
+    // up with select / input / button when used as a tree-select.
+    --wr-tree-trigger-radius: var(--wr-control-radius-md);
+    --wr-tree-trigger-padding-y: var(--wr-control-padding-y-md);
+    --wr-tree-trigger-padding-x: var(--wr-control-padding-x-md);
+    --wr-tree-trigger-font-size: var(--wr-control-font-size-md);
+    --wr-tree-trigger-line-height: var(--wr-control-line-height-md);
     --wr-tree-panel-max-height: 18rem;
 
     display: inline-flex;
@@ -202,7 +204,8 @@
     flex-wrap: wrap;
     align-items: center;
     padding: 0.25rem 0.5rem;
-    min-height: calc(var(--wr-tree-trigger-line-height) + var(--wr-tree-trigger-padding-y) * 2);
+    // Empty / one-row floor = single-mode height (+2px for the border).
+    min-height: calc(var(--wr-tree-trigger-line-height) + var(--wr-tree-trigger-padding-y) * 2 + 2px);
   }
 
   &__chips {

--- a/projects/lib/tree/styles/_index.scss
+++ b/projects/lib/tree/styles/_index.scss
@@ -5,7 +5,7 @@
 
   display: block;
   font-family: var(--wr-font-family-base);
-  font-size: 0.875rem;
+  font-size: var(--wr-text-sm);
   color: var(--wr-color-dark);
 
   &__list {
@@ -226,7 +226,7 @@
     border-radius: 999px;
     background: rgba(var(--wr-color-primary-rgb), 0.1);
     color: var(--wr-color-primary);
-    font-size: 0.8125rem;
+    font-size: var(--wr-text-sm);
     line-height: 1.4;
     user-select: none;
   }

--- a/projects/lib/window/styles/_index.scss
+++ b/projects/lib/window/styles/_index.scss
@@ -8,7 +8,7 @@
   --wr-window-radius: var(--wr-border-radius-base);
   --wr-window-handle-size: 8px;
   --wr-window-chrome-height: 2.25rem;
-  --wr-window-title-size: 0.8125rem;
+  --wr-window-title-size: var(--wr-text-sm);
   --wr-window-action-size: 1.5rem;
   --wr-window-anim-duration: 0.18s;
 
@@ -45,7 +45,7 @@
   // pixel of vertical space matters.
   &--chrome-compact {
     --wr-window-chrome-height: 1.625rem;
-    --wr-window-title-size: 0.75rem;
+    --wr-window-title-size: var(--wr-text-xs);
     --wr-window-action-size: 1.125rem;
   }
 
@@ -94,7 +94,7 @@
     align-items: center;
     gap: 0.375rem;
     padding-right: 0.375rem;
-    font-size: 0.75rem;
+    font-size: var(--wr-text-xs);
 
     &:empty {
       display: none;
@@ -223,7 +223,7 @@
     padding: 0.25rem 0.75rem;
     border-top: 1px solid var(--wr-window-border);
     background: rgba(var(--wr-color-light-rgb), 0.25);
-    font-size: 0.75rem;
+    font-size: var(--wr-text-xs);
     color: var(--wr-color-medium);
 
     &:empty {
@@ -374,7 +374,7 @@
     border-radius: var(--wr-border-radius-sm);
     color: var(--wr-color-dark);
     font-family: inherit;
-    font-size: 0.8125rem;
+    font-size: var(--wr-text-sm);
     line-height: 1.25rem;
     cursor: pointer;
     max-width: 12rem;


### PR DESCRIPTION
## Summary
Design-system overhaul: shared control-sizing contract + a sweep bringing the
whole catalog onto consistent size / radius / font tokens.

### Contract
- New --wr-control-{padding-y,padding-x,line-height,font-size,radius}-{sm,md,lg}
  (heights 22/30/36, radius 5/6/7, font 12/14/16). Height stays padding-derived
  so the density system keeps working.

### Size API (sm/md/lg)
- input (wrSize), select, cascader, checkbox, radio, switch, textarea,
  input-otp, segmented, rating; button already had it; tabs' size was inert
  (no class emitted) and is now wired.
- select + cascader dropdowns are size-aware. Fixed a select overlay bug where
  outside-clicks in the trigger-width gutter didn't close the panel.
- textarea gained a `resize` direction input + direction-aware corner grip.

### Radius
- Controls 5/6/7, containers base 10px, circles 50%; off-contract non-circles fixed.

### Fonts
- Whole catalog snapped to --wr-text-* (3 documented 10px micro-labels kept).