### PR TITLE
feat!: token-driven theming, alert redesign, density sm/md/lg

### DIFF
--- a/projects/lib/alert/alert.html
+++ b/projects/lib/alert/alert.html
@@ -1,5 +1,7 @@
 @if (!dismissed()) {
-  @if (icon()) {
+  @if (iconName(); as n) {
+    <wr-icon class="wr-alert__icon" [name]="n" />
+  } @else if (icon()) {
     <svg
       class="wr-alert__icon"
       xmlns="http://www.w3.org/2000/svg"
@@ -26,6 +28,15 @@
           <path d="M12 8v4" />
           <path d="M12 16h.01" />
         }
+        @case ('neutral') {
+          <circle cx="12" cy="12" r="10" />
+          <path d="M12 8v4" />
+          <path d="M12 16h.01" />
+        }
+        @case ('offline') {
+          <circle cx="12" cy="12" r="10" />
+          <path d="m4.9 4.9 14.2 14.2" />
+        }
         @default {
           <circle cx="12" cy="12" r="10" />
           <path d="M12 16v-4" />
@@ -36,9 +47,13 @@
   }
 
   <div class="wr-alert__body">
-    <p class="wr-alert__title">{{ title() }}</p>
-    @if (message(); as text) {
-      <p class="wr-alert__message">{{ text }}</p>
+    @if (title(); as t) {
+      <p class="wr-alert__title">{{ t }}</p>
+      @if (message(); as m) {
+        <p class="wr-alert__message">{{ m }}</p>
+      }
+    } @else if (message(); as m) {
+      <p class="wr-alert__title">{{ m }}</p>
     }
   </div>
 

--- a/projects/lib/alert/alert.ts
+++ b/projects/lib/alert/alert.ts
@@ -8,6 +8,8 @@
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { Component, ViewEncapsulation, computed, input, output, signal } from '@angular/core';
 
+import { WrIcon, type WrIconName } from 'ngwr/icon';
+
 import type { WrAlertType } from './interfaces';
 
 /**
@@ -24,6 +26,7 @@ import type { WrAlertType } from './interfaces';
 @Component({
   selector: 'wr-alert',
   templateUrl: './alert.html',
+  imports: [WrIcon],
   encapsulation: ViewEncapsulation.None,
   host: {
     '[class]': 'classes()',
@@ -32,8 +35,12 @@ import type { WrAlertType } from './interfaces';
   },
 })
 export class WrAlert {
-  /** Required headline shown at the top of the alert. */
-  readonly title = input.required<string>();
+  /**
+   * Optional headline shown at the top of the alert.
+   *
+   * @default null
+   */
+  readonly title = input<string | null>(null);
 
   /**
    * Visual variant.
@@ -43,6 +50,13 @@ export class WrAlert {
   readonly type = input<WrAlertType>('info');
 
   /**
+   * Override the default per-type icon with any ngwr icon name.
+   *
+   * @default null
+   */
+  readonly iconName = input<WrIconName | null>(null);
+
+  /**
    * Optional secondary message rendered below the title.
    *
    * @default null
@@ -50,8 +64,8 @@ export class WrAlert {
   readonly message = input<string | null>(null);
 
   /**
-   * When `true`, renders a leading status icon matching the `type`
-   * (info / success / warning / danger). Pass `false` to hide.
+   * When `true`, renders a leading status icon matching the `type`.
+   * Pass `false` to hide. Ignored when `iconName` is set.
    *
    * @default true
    */

--- a/projects/lib/alert/interfaces/alert-type.ts
+++ b/projects/lib/alert/interfaces/alert-type.ts
@@ -8,4 +8,4 @@
 /**
  * Visual variant of the alert.
  */
-export type WrAlertType = 'info' | 'success' | 'warning' | 'danger';
+export type WrAlertType = 'info' | 'success' | 'warning' | 'danger' | 'neutral' | 'offline';

--- a/projects/lib/alert/styles/_index.scss
+++ b/projects/lib/alert/styles/_index.scss
@@ -17,16 +17,16 @@ $alert-colors: (
   min-width: 0;
 
   // Defaults — overridden per variant below.
-  --wr-alert-bg: var(--wr-color-primary-soft);
-  --wr-alert-border: var(--wr-color-primary);
-  --wr-alert-title: var(--wr-color-primary);
+  --wr-alert-bg: var(--wr-color-info-soft);
+  --wr-alert-border: var(--wr-color-info-soft-border);
+  --wr-alert-title: var(--wr-color-info);
   --wr-alert-message: var(--wr-color-dark);
-  --wr-alert-close: var(--wr-color-medium);
+  --wr-alert-close: var(--wr-color-info);
 
   background: var(--wr-alert-bg);
-  border-left: 3px solid var(--wr-alert-border);
+  border: 1px solid var(--wr-alert-border);
   @include theme.smooth-br(var(--wr-border-radius-base));
-  padding: 0.75rem 1rem;
+  padding: 0.625rem 0.875rem;
 
   &--dismissed {
     display: none;
@@ -37,6 +37,14 @@ $alert-colors: (
     width: 1.125rem;
     height: 1.125rem;
     margin-top: 0.125rem;
+    color: var(--wr-alert-title);
+    // A custom `<wr-icon>` sizes via this var, not width/height.
+    --wr-icon-size: 1.125rem;
+  }
+
+  // `<wr-icon>` sets `color: inherit` on its own host at equal specificity;
+  // the type selector wins it back so a custom icon takes the intent colour.
+  wr-icon.wr-alert__icon {
     color: var(--wr-alert-title);
   }
 
@@ -84,20 +92,39 @@ $alert-colors: (
 
     &:hover {
       color: var(--wr-alert-title);
-      background: rgba(var(--wr-color-light-rgb), 0.4);
-    }
-
-    &:focus-visible {
-      outline: 2px solid rgba(var(--wr-color-primary-rgb), 0.5);
-      outline-offset: 1px;
+      background: var(--wr-color-hover);
     }
   }
 
   @each $variant, $color in $alert-colors {
     &--#{$variant} {
       --wr-alert-bg: var(--wr-color-#{$color}-soft);
-      --wr-alert-border: var(--wr-color-#{$color});
+      --wr-alert-border: var(--wr-color-#{$color}-soft-border);
       --wr-alert-title: var(--wr-color-#{$color});
+      --wr-alert-close: var(--wr-color-#{$color});
     }
+  }
+
+  // Neutral — muted gray chip, reusing the `medium` soft tokens.
+  &--neutral {
+    --wr-alert-bg: var(--wr-color-medium-soft);
+    --wr-alert-border: var(--wr-color-medium-soft-border);
+    --wr-alert-title: var(--wr-color-dark);
+    --wr-alert-message: var(--wr-color-medium);
+    --wr-alert-close: var(--wr-color-medium);
+
+    .wr-alert__icon {
+      color: var(--wr-color-medium);
+    }
+  }
+
+  // Offline — inverse chip. Auto-flips via the theme tokens: dark bg +
+  // light text in light theme; light bg + dark text in dark theme.
+  &--offline {
+    --wr-alert-bg: var(--wr-color-dark);
+    --wr-alert-border: var(--wr-color-dark);
+    --wr-alert-title: var(--wr-color-white);
+    --wr-alert-message: var(--wr-color-white);
+    --wr-alert-close: var(--wr-color-white);
   }
 }

--- a/projects/lib/alert/styles/_index.scss
+++ b/projects/lib/alert/styles/_index.scss
@@ -1,7 +1,7 @@
 @use '../../theme/styles' as theme;
 
 $alert-colors: (
-  info: primary,
+  info: info,
   success: success,
   warning: warning,
   danger: danger,
@@ -17,7 +17,7 @@ $alert-colors: (
   min-width: 0;
 
   // Defaults — overridden per variant below.
-  --wr-alert-bg: rgba(var(--wr-color-primary-rgb), 0.08);
+  --wr-alert-bg: var(--wr-color-primary-soft);
   --wr-alert-border: var(--wr-color-primary);
   --wr-alert-title: var(--wr-color-primary);
   --wr-alert-message: var(--wr-color-dark);
@@ -95,7 +95,7 @@ $alert-colors: (
 
   @each $variant, $color in $alert-colors {
     &--#{$variant} {
-      --wr-alert-bg: rgba(var(--wr-color-#{$color}-rgb), 0.08);
+      --wr-alert-bg: var(--wr-color-#{$color}-soft);
       --wr-alert-border: var(--wr-color-#{$color});
       --wr-alert-title: var(--wr-color-#{$color});
     }

--- a/projects/lib/avatar/styles/_index.scss
+++ b/projects/lib/avatar/styles/_index.scss
@@ -6,7 +6,7 @@
   // treatment.
   --wr-avatar-radius: 10%;
   --wr-avatar-img-opacity: 0;
-  --wr-avatar-ring: rgba(var(--wr-color-light-rgb), 0.5);
+  --wr-avatar-ring: var(--wr-color-border);
 
   display: inline-flex;
   align-items: center;

--- a/projects/lib/avatar/styles/_index.scss
+++ b/projects/lib/avatar/styles/_index.scss
@@ -49,7 +49,7 @@
 
   &__spin {
     position: absolute;
-    color: rgba(var(--wr-color-medium-rgb), 0.6);
+    color: var(--wr-color-text-faint);
     --wr-spinner-size: 40%;
   }
 }

--- a/projects/lib/breadcrumbs/styles/_index.scss
+++ b/projects/lib/breadcrumbs/styles/_index.scss
@@ -2,6 +2,8 @@
 // (set by the component from the `[separator]` input). All items except
 // the first prepend the glyph via a `::before` pseudo-element.
 
+@use '../../theme/styles' as theme;
+
 .wr-breadcrumbs {
   --wr-breadcrumbs-separator: '/';
   --wr-breadcrumbs-gap: 0.5rem;
@@ -56,7 +58,7 @@
     }
 
     &:focus-visible {
-      outline: 2px solid var(--wr-color-primary);
+      @include theme.focus-ring;
       outline-offset: 2px;
     }
   }

--- a/projects/lib/burger/styles/_index.scss
+++ b/projects/lib/burger/styles/_index.scss
@@ -42,7 +42,7 @@
     }
 
     &:focus-visible {
-      outline: 2px solid var(--wr-color-primary);
+      @include theme.focus-ring;
       outline-offset: 2px;
     }
 

--- a/projects/lib/burger/styles/_index.scss
+++ b/projects/lib/burger/styles/_index.scss
@@ -38,7 +38,7 @@
     transition: background var(--wr-transition-base);
 
     &:hover {
-      background: rgba(var(--wr-color-light-rgb), 0.4);
+      background: var(--wr-color-hover);
     }
 
     &:focus-visible {

--- a/projects/lib/button/styles/_index.scss
+++ b/projects/lib/button/styles/_index.scss
@@ -41,7 +41,7 @@
   transition: var(--wr-transition-base);
 
   &:hover {
-    --wr-btn-bg: rgba(var(--wr-color-light-rgb), 0.4);
+    --wr-btn-bg: var(--wr-color-hover);
   }
 
   &:active {

--- a/projects/lib/button/styles/_index.scss
+++ b/projects/lib/button/styles/_index.scss
@@ -206,7 +206,7 @@
   // edge. Outlined/default variants keep their own visible borders.
   @each $name in theme.$colors {
     > .wr-btn--#{$name}:not(.wr-btn--outlined):not(:first-child) {
-      box-shadow: inset 1px 0 0 rgb(0 0 0 / 20%);
+      box-shadow: inset 1px 0 0 rgba(var(--wr-color-black-rgb), 0.2);
     }
   }
 }

--- a/projects/lib/calendar/styles/_index.scss
+++ b/projects/lib/calendar/styles/_index.scss
@@ -52,7 +52,7 @@
       color var(--wr-transition-base);
 
     &:hover:not(:disabled) {
-      background: rgba(var(--wr-color-light-rgb), 0.5);
+      background: var(--wr-color-hover);
     }
 
     &:focus-visible {
@@ -82,7 +82,7 @@
 
     &:hover:not(:disabled) {
       color: var(--wr-calendar-color);
-      background: rgba(var(--wr-color-light-rgb), 0.5);
+      background: var(--wr-color-hover);
     }
 
     &:focus-visible {
@@ -144,7 +144,7 @@
       color var(--wr-transition-base);
 
     &:hover:not(:disabled):not(.wr-calendar__day--selected) {
-      background: rgba(var(--wr-color-light-rgb), 0.5);
+      background: var(--wr-color-hover);
     }
 
     &:focus-visible {
@@ -218,7 +218,7 @@
       color var(--wr-transition-base);
 
     &:hover:not(:disabled):not(.wr-calendar__chip--selected) {
-      background: rgba(var(--wr-color-light-rgb), 0.5);
+      background: var(--wr-color-hover);
     }
 
     &:focus-visible {

--- a/projects/lib/card/styles/_index.scss
+++ b/projects/lib/card/styles/_index.scss
@@ -75,7 +75,7 @@
     align-items: center;
     justify-content: center;
     @include theme.smooth-br(var(--wr-card-radius));
-    background: rgb(255 255 255 / 50%);
+    background: rgba(var(--wr-color-white-rgb), 0.5);
     pointer-events: none;
   }
 

--- a/projects/lib/carousel/styles/_index.scss
+++ b/projects/lib/carousel/styles/_index.scss
@@ -88,7 +88,7 @@
     border: 0;
     border-radius: 50%;
     background: rgba(var(--wr-color-white-rgb), 0.55);
-    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 0 0 1px rgba(var(--wr-color-black-rgb), 0.15);
     cursor: pointer;
     transition:
       width var(--wr-transition-base),

--- a/projects/lib/cascader/styles/_index.scss
+++ b/projects/lib/cascader/styles/_index.scss
@@ -178,11 +178,11 @@
     transition: background var(--wr-transition-short);
 
     &:hover {
-      background: rgba(var(--wr-color-light-rgb), 0.4);
+      background: var(--wr-color-hover);
     }
 
     &--active {
-      background: rgba(var(--wr-color-primary-rgb), 0.1);
+      background: var(--wr-color-primary-soft);
       color: var(--wr-color-primary);
       font-weight: 500;
     }

--- a/projects/lib/cascader/styles/_index.scss
+++ b/projects/lib/cascader/styles/_index.scss
@@ -2,6 +2,8 @@
 // is a horizontal row of columns where each column lists the children
 // of the previously-active node. Picking a leaf commits the path.
 
+@use '../../theme/styles' as theme;
+
 .wr-cascader {
   --wr-cascader-color: var(--wr-color-dark);
   --wr-cascader-bg: var(--wr-color-white);
@@ -61,9 +63,8 @@
       box-shadow var(--wr-transition-base);
 
     &:focus-visible {
-      outline: none;
       border-color: var(--wr-color-primary);
-      box-shadow: 0 0 0 3px rgba(var(--wr-color-primary-rgb), 0.15);
+      @include theme.focus-ring;
     }
 
     &:disabled {
@@ -85,7 +86,7 @@
   }
 
   &__placeholder {
-    color: rgba(var(--wr-color-medium-rgb), 0.85);
+    color: var(--wr-color-text-muted);
   }
 
   &__chevron {

--- a/projects/lib/color-picker/styles/_index.scss
+++ b/projects/lib/color-picker/styles/_index.scss
@@ -23,7 +23,7 @@
   background: var(--wr-color-picker-bg);
   border: 1px solid var(--wr-color-picker-border);
   @include theme.smooth-br(var(--wr-color-picker-radius));
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+  box-shadow: var(--wr-shadow-overlay);
   font-family: var(--wr-font-family-base);
   user-select: none;
 

--- a/projects/lib/color-picker/styles/_index.scss
+++ b/projects/lib/color-picker/styles/_index.scss
@@ -38,7 +38,7 @@
     background:
       linear-gradient(to top, #000, transparent), linear-gradient(to right, #fff, transparent),
       var(--wr-color-picker-hue);
-    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.06);
+    box-shadow: inset 0 0 0 1px rgba(var(--wr-color-black-rgb), 0.06);
   }
 
   // Hue + alpha sliders
@@ -49,7 +49,7 @@
     border-radius: var(--wr-color-picker-slider-height);
     cursor: ew-resize;
     touch-action: none;
-    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.06);
+    box-shadow: inset 0 0 0 1px rgba(var(--wr-color-black-rgb), 0.06);
 
     // Coarse pointers: a taller track is easier to drag than the 0.75rem
     // default. A symmetric 44px hit area would overlap the SV panel above it,
@@ -92,8 +92,8 @@
     border-radius: 50%;
     border: 2px solid #fff;
     box-shadow:
-      0 0 0 1px rgba(0, 0, 0, 0.3),
-      0 1px 2px rgba(0, 0, 0, 0.25);
+      0 0 0 1px rgba(var(--wr-color-black-rgb), 0.3),
+      0 1px 2px rgba(var(--wr-color-black-rgb), 0.25);
     pointer-events: none;
     background: transparent;
   }
@@ -116,7 +116,7 @@
     background-size:
       auto,
       8px 8px;
-    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.06);
+    box-shadow: inset 0 0 0 1px rgba(var(--wr-color-black-rgb), 0.06);
     color: transparent; // background-image already set inline via [style.background]
   }
 

--- a/projects/lib/color-picker/styles/_index.scss
+++ b/projects/lib/color-picker/styles/_index.scss
@@ -231,8 +231,7 @@
     }
 
     &:focus-visible {
-      outline: none;
-      box-shadow: 0 0 0 2px var(--wr-color-primary);
+      @include theme.focus-ring;
     }
 
     &:disabled {

--- a/projects/lib/command-palette/styles/_index.scss
+++ b/projects/lib/command-palette/styles/_index.scss
@@ -14,7 +14,7 @@
   &__backdrop {
     position: absolute;
     inset: 0;
-    background: rgba(var(--wr-color-backdrop-rgb), 0.45);
+    background: var(--wr-color-overlay);
     backdrop-filter: blur(4px);
     pointer-events: auto;
     animation: wr-cmd-fade var(--wr-duration-base) var(--wr-ease-out);
@@ -107,7 +107,7 @@
     user-select: none;
 
     &--active {
-      background: rgba(var(--wr-color-primary-rgb), 0.08);
+      background: var(--wr-color-primary-soft);
       color: var(--wr-color-primary);
     }
   }
@@ -152,7 +152,7 @@
     padding: 0.0625rem 0.375rem;
     border: 1px solid var(--wr-color-light);
     border-radius: var(--wr-border-radius-sm);
-    background: rgba(var(--wr-color-light-rgb), 0.4);
+    background: var(--wr-color-hover);
     color: var(--wr-color-medium);
     font-family: inherit;
     font-size: var(--wr-text-xs);

--- a/projects/lib/compare/styles/_index.scss
+++ b/projects/lib/compare/styles/_index.scss
@@ -63,7 +63,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 0 0 1px rgba(var(--wr-color-black-rgb), 0.2);
   }
 
   &--horizontal &__divider {
@@ -94,7 +94,7 @@
     background: var(--wr-color-white);
     color: var(--wr-color-dark);
     border-radius: 50%;
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+    box-shadow: 0 2px 6px rgba(var(--wr-color-black-rgb), 0.25);
     pointer-events: none;
   }
 }

--- a/projects/lib/compare/styles/_index.scss
+++ b/projects/lib/compare/styles/_index.scss
@@ -13,7 +13,7 @@
     outline: 0;
 
     &:focus-visible {
-      box-shadow: 0 0 0 3px rgba(var(--wr-color-primary-rgb), 0.25);
+      @include theme.focus-ring;
       border-radius: var(--wr-border-radius-sm);
     }
   }

--- a/projects/lib/context-menu/styles/_index.scss
+++ b/projects/lib/context-menu/styles/_index.scss
@@ -64,7 +64,7 @@
 
   &:hover,
   &:focus-visible {
-    background: rgba(var(--wr-color-primary-rgb), 0.08);
+    background: var(--wr-color-primary-soft);
     color: var(--wr-color-primary);
     outline: none;
   }

--- a/projects/lib/date-picker/styles/_index.scss
+++ b/projects/lib/date-picker/styles/_index.scss
@@ -94,12 +94,11 @@
 
     &:hover:not(:disabled) {
       color: var(--wr-color-primary);
-      background: rgba(var(--wr-color-light-rgb), 0.5);
+      background: var(--wr-color-hover);
     }
 
     &:focus-visible {
-      outline: none;
-      box-shadow: 0 0 0 2px rgba(var(--wr-color-primary-rgb), 0.3);
+      @include theme.focus-ring;
     }
 
     &:disabled {

--- a/projects/lib/density/density-config.ts
+++ b/projects/lib/density/density-config.ts
@@ -10,7 +10,7 @@ import { InjectionToken } from '@angular/core';
 import type { WrDensityConfig } from './interfaces';
 
 export const DEFAULT_WR_DENSITY_CONFIG: WrDensityConfig = {
-  defaultDensity: 'default',
+  defaultDensity: 'md',
   storageKey: 'wr-density',
   attribute: 'data-wr-density',
 };

--- a/projects/lib/density/density.directive.ts
+++ b/projects/lib/density/density.directive.ts
@@ -16,8 +16,8 @@ import { WR_DENSITY_CONFIG, type WrDensityValue } from './density-config';
  *
  * @example
  * ```html
- * <!-- The whole sidebar is compact, the rest of the app keeps its global density. -->
- * <aside wrDensity="compact">
+ * <!-- The whole sidebar is sm, the rest of the app keeps its global density. -->
+ * <aside wrDensity="sm">
  *   <wr-list ...></wr-list>
  * </aside>
  * ```

--- a/projects/lib/density/density.ts
+++ b/projects/lib/density/density.ts
@@ -12,7 +12,7 @@ import { WrStorage } from 'ngwr/storage';
 
 import { WR_DENSITY_CONFIG, type WrDensityValue } from './density-config';
 
-const VALID: readonly WrDensityValue[] = ['compact', 'default', 'comfortable', 'touch'];
+const VALID: readonly WrDensityValue[] = ['sm', 'md', 'lg', 'touch'];
 
 function isDensity(v: unknown): v is WrDensityValue {
   return typeof v === 'string' && (VALID as readonly string[]).includes(v);
@@ -31,8 +31,8 @@ function isDensity(v: unknown): v is WrDensityValue {
  * @example
  * ```ts
  * const density = inject(WrDensity);
- * density.set('compact');
- * density.current();   // 'compact'
+ * density.set('sm');
+ * density.current();   // 'sm'
  * ```
  *
  * @see https://ngwr.dev/services/density
@@ -64,9 +64,9 @@ export class WrDensity {
     this._current.set(density);
   }
 
-  /** Cycle compact → default → comfortable → touch → compact … */
+  /** Cycle sm → md → lg → touch → sm … */
   cycle(): void {
-    const order: readonly WrDensityValue[] = ['compact', 'default', 'comfortable', 'touch'];
+    const order: readonly WrDensityValue[] = ['sm', 'md', 'lg', 'touch'];
     const i = order.indexOf(this._current());
     this._current.set(order[(i + 1) % order.length]);
   }

--- a/projects/lib/density/interfaces/index.ts
+++ b/projects/lib/density/interfaces/index.ts
@@ -1,9 +1,9 @@
 /** Density scale. Components multiply their paddings by the matching multiplier. */
-type WrDensityValue = 'compact' | 'default' | 'comfortable' | 'touch';
+type WrDensityValue = 'sm' | 'md' | 'lg' | 'touch';
 
 /** Configuration for {@link WrDensityValueService}. */
 interface WrDensityConfig {
-  /** Initial density used when no persisted value is present. @default 'default' */
+  /** Initial density used when no persisted value is present. @default 'md' */
   readonly defaultDensity: WrDensityValue;
   /** Storage key for persistence (via `WrStorage`). Set to `null` to disable. @default 'wr-density' */
   readonly storageKey: string | null;

--- a/projects/lib/density/styles/_index.scss
+++ b/projects/lib/density/styles/_index.scss
@@ -15,21 +15,21 @@
   --wr-density-gap: 1;
 }
 
-[data-wr-density='compact'] {
+[data-wr-density='sm'] {
   --wr-density-y: 0.55;
   --wr-density-x: 0.85;
   --wr-density-text: 0.95;
   --wr-density-gap: 0.8;
 }
 
-[data-wr-density='default'] {
+[data-wr-density='md'] {
   --wr-density-y: 1;
   --wr-density-x: 1;
   --wr-density-text: 1;
   --wr-density-gap: 1;
 }
 
-[data-wr-density='comfortable'] {
+[data-wr-density='lg'] {
   --wr-density-y: 1.35;
   --wr-density-x: 1.15;
   --wr-density-text: 1.05;

--- a/projects/lib/dialog/styles/_index.scss
+++ b/projects/lib/dialog/styles/_index.scss
@@ -47,7 +47,7 @@
 }
 
 .wr-dialog-backdrop {
-  background: rgba(var(--wr-color-backdrop-rgb), 0.45);
+  background: var(--wr-color-overlay);
   backdrop-filter: blur(2px);
 }
 

--- a/projects/lib/drawer/styles/_index.scss
+++ b/projects/lib/drawer/styles/_index.scss
@@ -1,7 +1,7 @@
 @use '../../theme/styles' as theme;
 
 .wr-drawer-backdrop {
-  background: rgba(var(--wr-color-backdrop-rgb), 0.45);
+  background: var(--wr-color-overlay);
   backdrop-filter: blur(2px);
 }
 

--- a/projects/lib/dropdown/styles/_index.scss
+++ b/projects/lib/dropdown/styles/_index.scss
@@ -61,7 +61,7 @@
   --wr-dropdown-item-padding-y: 0.375rem;
   --wr-dropdown-item-padding-x: 0.625rem;
   --wr-dropdown-item-color: var(--wr-color-dark);
-  --wr-dropdown-item-bg-hover: rgba(var(--wr-color-light-rgb), 0.4);
+  --wr-dropdown-item-bg-hover: var(--wr-color-hover);
   --wr-dropdown-item-radius: var(--wr-border-radius-sm);
 
   display: flex;

--- a/projects/lib/image-cropper/styles/_index.scss
+++ b/projects/lib/image-cropper/styles/_index.scss
@@ -25,7 +25,7 @@
   &__backdrop {
     position: absolute;
     inset: 0;
-    background: rgba(var(--wr-color-backdrop-rgb), 0.5);
+    background: var(--wr-color-overlay);
     pointer-events: none;
   }
 
@@ -107,7 +107,7 @@
     padding: 2rem;
     text-align: center;
     color: var(--wr-color-medium);
-    background: rgba(var(--wr-color-light-rgb), 0.4);
+    background: var(--wr-color-hover);
     border: 1px dashed var(--wr-color-light);
     @include theme.smooth-br(var(--wr-border-radius-base));
   }

--- a/projects/lib/image-cropper/styles/_index.scss
+++ b/projects/lib/image-cropper/styles/_index.scss
@@ -44,7 +44,7 @@
     background: var(--wr-color-white);
     border: 1px solid var(--wr-color-primary);
     border-radius: 50%;
-    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 0 0 1px rgba(var(--wr-color-black-rgb), 0.15);
     box-sizing: border-box;
 
     // Position each handle by its edge / corner.

--- a/projects/lib/input-otp/styles/_index.scss
+++ b/projects/lib/input-otp/styles/_index.scss
@@ -34,7 +34,7 @@
       box-shadow var(--wr-transition-base);
 
     &::placeholder {
-      color: rgba(var(--wr-color-medium-rgb), 0.5);
+      color: var(--wr-color-text-faint);
     }
 
     &:focus {

--- a/projects/lib/knob/styles/_index.scss
+++ b/projects/lib/knob/styles/_index.scss
@@ -14,7 +14,7 @@
     outline: 0;
 
     &:focus-visible {
-      box-shadow: 0 0 0 3px rgba(var(--wr-color-primary-rgb), 0.2);
+      @include theme.focus-ring;
       border-radius: 50%;
     }
 

--- a/projects/lib/lightbox/styles/_index.scss
+++ b/projects/lib/lightbox/styles/_index.scss
@@ -95,8 +95,8 @@
     padding: 0;
     border: 0;
     border-radius: 999px;
-    background: rgba(255, 255, 255, 0.12);
-    color: rgba(255, 255, 255, 0.9);
+    background: rgba(var(--wr-color-white-rgb), 0.12);
+    color: rgba(var(--wr-color-white-rgb), 0.9);
     cursor: pointer;
     transition:
       background 0.15s ease,
@@ -105,7 +105,7 @@
     @include theme.touch-target($positioned: true); // 36px -> 44px tap area on touch
 
     &:hover {
-      background: rgba(255, 255, 255, 0.2);
+      background: rgba(var(--wr-color-white-rgb), 0.2);
     }
 
     &:active {
@@ -113,7 +113,7 @@
     }
 
     &:focus-visible {
-      outline: 2px solid rgba(255, 255, 255, 0.9);
+      outline: 2px solid rgba(var(--wr-color-white-rgb), 0.9);
       outline-offset: 2px;
     }
   }
@@ -128,7 +128,7 @@
   }
 
   &__caption {
-    color: rgba(255, 255, 255, 0.85);
+    color: rgba(var(--wr-color-white-rgb), 0.85);
     font-family: var(--wr-font-family-base);
     font-size: var(--wr-text-sm);
     text-align: center;

--- a/projects/lib/lightbox/styles/_index.scss
+++ b/projects/lib/lightbox/styles/_index.scss
@@ -9,7 +9,7 @@
   overflow: hidden;
   @include theme.smooth-br(var(--wr-lightbox-radius, var(--wr-border-radius-base)));
   cursor: zoom-in;
-  background: rgba(var(--wr-color-light-rgb), 0.4);
+  background: var(--wr-color-hover);
 
   &--loading::after {
     content: '';

--- a/projects/lib/list/styles/_index.scss
+++ b/projects/lib/list/styles/_index.scss
@@ -65,7 +65,7 @@
       }
 
       &:focus-visible {
-        outline: 2px solid var(--wr-color-primary);
+        @include theme.focus-ring;
         outline-offset: -2px;
       }
     }

--- a/projects/lib/list/styles/_index.scss
+++ b/projects/lib/list/styles/_index.scss
@@ -11,7 +11,7 @@
   --wr-list-item-gap: 0.75rem;
   --wr-list-divider-color: var(--wr-color-light);
   --wr-list-bg: transparent;
-  --wr-list-hover-bg: rgba(var(--wr-color-light-rgb), 0.4);
+  --wr-list-hover-bg: var(--wr-color-hover);
   --wr-list-active-bg: rgba(var(--wr-color-primary-rgb), 0.08);
 
   display: block;

--- a/projects/lib/overlay/styles/_index.scss
+++ b/projects/lib/overlay/styles/_index.scss
@@ -17,7 +17,7 @@
 
 // Dim + blur behind a sheet — for overlays that otherwise have no backdrop.
 .wr-overlay-backdrop {
-  background: rgba(var(--wr-color-backdrop-rgb), 0.45);
+  background: var(--wr-color-overlay);
   backdrop-filter: blur(2px);
 }
 

--- a/projects/lib/popover/styles/_index.scss
+++ b/projects/lib/popover/styles/_index.scss
@@ -38,7 +38,7 @@
   font-family: var(--wr-font-family-base);
   font-size: var(--wr-text-xs);
   line-height: 1rem;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--wr-shadow-overlay);
   animation: wr-overlay-in var(--wr-overlay-duration) var(--wr-overlay-ease);
   transform-origin: top left;
 

--- a/projects/lib/rating/styles/_index.scss
+++ b/projects/lib/rating/styles/_index.scss
@@ -16,7 +16,7 @@
     outline: 0;
 
     &:focus-visible {
-      box-shadow: 0 0 0 3px rgba(var(--wr-color-primary-rgb), 0.2);
+      @include theme.focus-ring;
       border-radius: var(--wr-border-radius-sm);
     }
   }

--- a/projects/lib/schematics/ng-add/index.ts
+++ b/projects/lib/schematics/ng-add/index.ts
@@ -31,11 +31,11 @@ const DATE_ADAPTER_PROVIDER: Record<NonNullable<Schema['dateAdapter']>, string |
   luxon: 'provideWrDateAdapter({ adapter: WrLuxonAdapter })',
 };
 
-/** Density preset → `provideWrDensity(...)` call. */
+/** Default density → `provideWrDensity(...)` call. */
 const DENSITY_PROVIDER: Record<NonNullable<Schema['density']>, string | null> = {
   none: null,
-  comfortable: "provideWrDensity({ preset: 'comfortable' })",
-  compact: "provideWrDensity({ preset: 'compact' })",
+  sm: "provideWrDensity({ defaultDensity: 'sm' })",
+  lg: "provideWrDensity({ defaultDensity: 'lg' })",
 };
 
 /** Theme preset → `provideWrTheme(...)` call. */

--- a/projects/lib/schematics/ng-add/schema.json
+++ b/projects/lib/schematics/ng-add/schema.json
@@ -41,16 +41,16 @@
     },
     "density": {
       "type": "string",
-      "enum": ["none", "comfortable", "compact"],
+      "enum": ["none", "sm", "lg"],
       "default": "none",
-      "description": "Density preset wired via `provideWrDensity()`. `none` uses lib defaults.",
+      "description": "Default density wired via `provideWrDensity()`. `none` uses lib defaults (md).",
       "x-prompt": {
-        "message": "Pick a density preset",
+        "message": "Pick a default density",
         "type": "list",
         "items": [
-          { "value": "none", "label": "None — use lib defaults" },
-          { "value": "comfortable", "label": "Comfortable — relaxed spacing" },
-          { "value": "compact", "label": "Compact — tight spacing" }
+          { "value": "none", "label": "None — use lib defaults (md)" },
+          { "value": "sm", "label": "sm — tight spacing" },
+          { "value": "lg", "label": "lg — relaxed spacing" }
         ]
       }
     },

--- a/projects/lib/schematics/ng-add/schema.ts
+++ b/projects/lib/schematics/ng-add/schema.ts
@@ -16,8 +16,8 @@ export interface Schema {
   /** Date adapter wired via `provideWrDateAdapter`. */
   dateAdapter?: 'none' | 'native' | 'date-fns' | 'luxon';
 
-  /** Density preset wired via `provideWrDensity`. */
-  density?: 'none' | 'comfortable' | 'compact';
+  /** Default density wired via `provideWrDensity`. */
+  density?: 'none' | 'sm' | 'lg';
 
   /** Theme starter applied to `<html data-wr-theme="...">`. */
   theme?: 'none' | 'light' | 'dark' | 'system';

--- a/projects/lib/schematics/provider/schema.json
+++ b/projects/lib/schematics/provider/schema.json
@@ -29,7 +29,7 @@
           { "value": "toast", "label": "toast — global toast service" },
           { "value": "i18n", "label": "i18n — Transloco-class translation core" },
           { "value": "date-adapter", "label": "date-adapter — calendar / date-picker plumbing" },
-          { "value": "density", "label": "density — comfortable / compact preset" },
+          { "value": "density", "label": "density — sm / md / lg scale" },
           { "value": "loading-bar", "label": "loading-bar — router-aware progress bar" },
           { "value": "cookie", "label": "cookie — wr cookie service" },
           { "value": "storage", "label": "storage — swappable engine + TTL" },

--- a/projects/lib/segmented/styles/_index.scss
+++ b/projects/lib/segmented/styles/_index.scss
@@ -54,7 +54,7 @@
     transform: translateX(calc(100% * var(--wr-segmented-thumb-index)));
     background: var(--wr-segmented-selected-bg);
     @include theme.smooth-br(var(--wr-segmented-thumb-radius));
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--wr-shadow-xs);
     pointer-events: none;
     // Animate slides, but only after first paint — see `&--mounted` below.
   }

--- a/projects/lib/select/styles/_index.scss
+++ b/projects/lib/select/styles/_index.scss
@@ -67,9 +67,8 @@
       box-shadow var(--wr-transition-base);
 
     &:focus-visible {
-      outline: none;
       border-color: var(--wr-color-primary);
-      box-shadow: 0 0 0 3px rgba(var(--wr-color-primary-rgb), 0.15);
+      @include theme.focus-ring;
     }
 
     &:disabled {
@@ -91,7 +90,7 @@
   }
 
   &__placeholder {
-    color: rgba(var(--wr-color-medium-rgb), 0.85);
+    color: var(--wr-color-text-muted);
   }
 
   &__chevron {
@@ -143,7 +142,7 @@
     line-height: var(--wr-select-line-height);
 
     &::placeholder {
-      color: rgba(var(--wr-color-medium-rgb), 0.85);
+      color: var(--wr-color-text-muted);
     }
 
     &:disabled {
@@ -174,7 +173,7 @@
     line-height: var(--wr-select-line-height);
 
     &::placeholder {
-      color: rgba(var(--wr-color-medium-rgb), 0.85);
+      color: var(--wr-color-text-muted);
     }
 
     &:disabled {

--- a/projects/lib/select/styles/_index.scss
+++ b/projects/lib/select/styles/_index.scss
@@ -198,7 +198,7 @@
     max-width: 100%;
     padding: 0.125rem 0.25rem 0.125rem 0.5rem;
     border-radius: 999px;
-    background: rgba(var(--wr-color-primary-rgb), 0.1);
+    background: var(--wr-color-primary-soft);
     color: var(--wr-color-primary);
     font-size: var(--wr-text-sm);
     line-height: 1.4;
@@ -223,7 +223,7 @@
     transition: background 0.12s ease;
 
     &:hover {
-      background: rgba(var(--wr-color-primary-rgb), 0.2);
+      background: var(--wr-color-primary-active);
     }
   }
 
@@ -325,11 +325,11 @@
   transition: background var(--wr-transition-short);
 
   &:hover {
-    background: rgba(var(--wr-color-light-rgb), 0.4);
+    background: var(--wr-color-hover);
   }
 
   &--selected {
-    background: rgba(var(--wr-color-primary-rgb), 0.1);
+    background: var(--wr-color-primary-soft);
     color: var(--wr-color-primary);
     font-weight: 500;
   }

--- a/projects/lib/sidebar/styles/_index.scss
+++ b/projects/lib/sidebar/styles/_index.scss
@@ -43,7 +43,7 @@
 
     &--active {
       color: var(--wr-color-primary);
-      background: rgba(var(--wr-color-primary-rgb), 0.1);
+      background: var(--wr-color-primary-soft);
       pointer-events: none;
 
       .wr-sidebar__icon {
@@ -175,7 +175,7 @@
 
     &--active {
       color: var(--wr-color-primary);
-      background: rgba(var(--wr-color-primary-rgb), 0.1);
+      background: var(--wr-color-primary-soft);
       pointer-events: none;
 
       &::before {

--- a/projects/lib/sidebar/styles/_index.scss
+++ b/projects/lib/sidebar/styles/_index.scss
@@ -34,7 +34,7 @@
       color var(--wr-transition-base);
 
     &:hover {
-      background: rgba(var(--wr-color-light-rgb), 0.5);
+      background: var(--wr-color-hover);
 
       .wr-sidebar__icon {
         color: var(--wr-color-primary);

--- a/projects/lib/slider/styles/_index.scss
+++ b/projects/lib/slider/styles/_index.scss
@@ -53,8 +53,7 @@
     @include theme.touch-target($positioned: true);
 
     &:focus-visible {
-      outline: none;
-      box-shadow: 0 0 0 3px rgba(var(--wr-color-primary-rgb), 0.25);
+      @include theme.focus-ring;
     }
 
     &:active {

--- a/projects/lib/splitter/styles/_index.scss
+++ b/projects/lib/splitter/styles/_index.scss
@@ -44,7 +44,7 @@
     }
 
     &:focus-visible {
-      box-shadow: 0 0 0 2px rgba(var(--wr-color-primary-rgb), 0.2);
+      @include theme.focus-ring;
     }
   }
 

--- a/projects/lib/splitter/styles/_index.scss
+++ b/projects/lib/splitter/styles/_index.scss
@@ -61,7 +61,7 @@
   &__handle {
     background: var(--wr-color-white);
     border: 1px solid var(--wr-color-light);
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--wr-shadow-sm);
     display: inline-block;
     flex: 0 0 auto;
   }

--- a/projects/lib/stepper/styles/_index.scss
+++ b/projects/lib/stepper/styles/_index.scss
@@ -95,7 +95,7 @@
   &__header--active &__indicator {
     border-color: var(--wr-color-primary);
     color: var(--wr-color-primary);
-    background: rgba(var(--wr-color-primary-rgb), 0.08);
+    background: var(--wr-color-primary-soft);
   }
 
   &__header--completed &__indicator {

--- a/projects/lib/switch/styles/_index.scss
+++ b/projects/lib/switch/styles/_index.scss
@@ -61,7 +61,7 @@
     height: var(--wr-switch-thumb-size);
     background: var(--wr-switch-thumb);
     border-radius: 50%;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+    box-shadow: var(--wr-shadow-xs);
     transition: left var(--wr-transition-base);
   }
 

--- a/projects/lib/table/styles/_index.scss
+++ b/projects/lib/table/styles/_index.scss
@@ -310,7 +310,7 @@
     text-align: left;
 
     &:hover {
-      background: rgba(var(--wr-color-primary-rgb), 0.08);
+      background: var(--wr-color-primary-soft);
     }
   }
 }

--- a/projects/lib/textarea/styles/_index.scss
+++ b/projects/lib/textarea/styles/_index.scss
@@ -97,7 +97,7 @@
     right: 0.25rem;
     bottom: 0.25rem;
     display: inline-flex;
-    color: rgba(var(--wr-color-medium-rgb), 0.55);
+    color: var(--wr-color-text-faint);
     touch-action: none;
     transition: color var(--wr-transition-base);
 

--- a/projects/lib/theme/styles/_colors.scss
+++ b/projects/lib/theme/styles/_colors.scss
@@ -80,6 +80,11 @@ $contrast-light: #ffffff !default;
   // regardless of theme.
   --wr-color-overlay: rgba(var(--wr-color-backdrop-rgb), 0.45);
 
+  // De-emphasized text — `medium` dimmed to two canonical strengths so muted
+  // labels / captions / placeholders read consistently. One place each.
+  --wr-color-text-muted: rgba(var(--wr-color-medium-rgb), 0.85);
+  --wr-color-text-faint: rgba(var(--wr-color-medium-rgb), 0.6);
+
   @each $name, $base in $base-colors {
     --wr-color-#{$name}: #{$base};
     --wr-color-#{$name}-rgb: #{_rgb-channels($base)};

--- a/projects/lib/theme/styles/_colors.scss
+++ b/projects/lib/theme/styles/_colors.scss
@@ -15,6 +15,7 @@ $base-colors: (
   success: #00a400,
   warning: #ffba00,
   danger: #fa383e,
+  info: #3b82f6,
   light: #cbd5e1,
   medium: #8594a4,
   dark: #0f172a,
@@ -73,6 +74,17 @@ $contrast-light: #ffffff !default;
     --wr-color-#{$name}-darker: #{color.adjust($base, $lightness: -10%)};
     --wr-color-#{$name}-light: #{color.adjust($base, $lightness: 5%)};
     --wr-color-#{$name}-lighter: #{color.adjust($base, $lightness: 10%)};
+  }
+
+  // Soft tint pair per intent — tokenizes the ad-hoc
+  // `rgba(var(--*-rgb), α)` fills components hand-rolled at ~8 different
+  // alphas. `-soft` is one canonical low-alpha fill (theme-correct over
+  // any background via the -rgb channels); `-soft-contrast` is the
+  // readable same-hue text on it (deep in light, light in dark — it
+  // follows `--wr-color-dark`).
+  @each $name in (primary, secondary, success, warning, danger, info) {
+    --wr-color-#{$name}-soft: rgba(var(--wr-color-#{$name}-rgb), 0.12);
+    --wr-color-#{$name}-soft-contrast: color-mix(in srgb, var(--wr-color-#{$name}) 62%, var(--wr-color-dark));
   }
 }
 

--- a/projects/lib/theme/styles/_colors.scss
+++ b/projects/lib/theme/styles/_colors.scss
@@ -70,6 +70,16 @@ $contrast-light: #ffffff !default;
   // so the hover strength stays consistent everywhere.
   --wr-color-hover: rgba(var(--wr-color-light-rgb), 0.4);
 
+  // Border / divider strengths — translucent so they read on any surface and
+  // auto-adapt in dark (via the flipping `light` channels). One place each.
+  --wr-color-border: rgba(var(--wr-color-light-rgb), 0.5);
+  --wr-color-border-subtle: rgba(var(--wr-color-light-rgb), 0.35);
+  --wr-color-border-strong: rgba(var(--wr-color-light-rgb), 0.6);
+
+  // Scrim behind modals / drawers — always black so the dim reads as "covered"
+  // regardless of theme.
+  --wr-color-overlay: rgba(var(--wr-color-backdrop-rgb), 0.45);
+
   @each $name, $base in $base-colors {
     --wr-color-#{$name}: #{$base};
     --wr-color-#{$name}-rgb: #{_rgb-channels($base)};
@@ -91,6 +101,7 @@ $contrast-light: #ffffff !default;
     --wr-color-#{$name}-soft: rgba(var(--wr-color-#{$name}-rgb), 0.12);
     --wr-color-#{$name}-soft-border: rgba(var(--wr-color-#{$name}-rgb), 0.3);
     --wr-color-#{$name}-soft-contrast: color-mix(in srgb, var(--wr-color-#{$name}) 62%, var(--wr-color-dark));
+    --wr-color-#{$name}-active: rgba(var(--wr-color-#{$name}-rgb), 0.2);
   }
 }
 

--- a/projects/lib/theme/styles/_colors.scss
+++ b/projects/lib/theme/styles/_colors.scss
@@ -66,6 +66,10 @@ $contrast-light: #ffffff !default;
   // and turns the backdrop into a white wash.
   --wr-color-backdrop-rgb: 0, 0, 0;
 
+  // Generic subtle hover-surface tint (icon buttons, list rows) — one place
+  // so the hover strength stays consistent everywhere.
+  --wr-color-hover: rgba(var(--wr-color-light-rgb), 0.4);
+
   @each $name, $base in $base-colors {
     --wr-color-#{$name}: #{$base};
     --wr-color-#{$name}-rgb: #{_rgb-channels($base)};
@@ -76,14 +80,16 @@ $contrast-light: #ffffff !default;
     --wr-color-#{$name}-lighter: #{color.adjust($base, $lightness: 10%)};
   }
 
-  // Soft tint pair per intent — tokenizes the ad-hoc
-  // `rgba(var(--*-rgb), α)` fills components hand-rolled at ~8 different
-  // alphas. `-soft` is one canonical low-alpha fill (theme-correct over
-  // any background via the -rgb channels); `-soft-contrast` is the
-  // readable same-hue text on it (deep in light, light in dark — it
-  // follows `--wr-color-dark`).
-  @each $name in (primary, secondary, success, warning, danger, info) {
+  // Soft trio per intent (+ `medium` for neutral surfaces) — tokenizes the
+  // ad-hoc `rgba(var(--*-rgb), α)` fills components hand-rolled at ~8
+  // different alphas, so each alpha lives in ONE place. `-soft` is the
+  // canonical low-alpha fill, `-soft-border` the matching hairline, and
+  // `-soft-contrast` the readable same-hue text on it (deep in light,
+  // light in dark — follows `--wr-color-dark`). All theme-correct over any
+  // background via the -rgb channels.
+  @each $name in (primary, secondary, success, warning, danger, info, medium) {
     --wr-color-#{$name}-soft: rgba(var(--wr-color-#{$name}-rgb), 0.12);
+    --wr-color-#{$name}-soft-border: rgba(var(--wr-color-#{$name}-rgb), 0.3);
     --wr-color-#{$name}-soft-contrast: color-mix(in srgb, var(--wr-color-#{$name}) 62%, var(--wr-color-dark));
   }
 }

--- a/projects/lib/theme/styles/_dark.scss
+++ b/projects/lib/theme/styles/_dark.scss
@@ -1,9 +1,21 @@
+@use 'sass:color';
+
 // Dark theme overrides — opt-in via `[data-theme="dark"]` on <html>.
 // Drive the toggle from `WrTheme` (provided automatically with
 // `provideWrTheme(...)`).
 //
 // Only semantic tokens flip — palette hues stay so brand-coloured
 // elements look the same regardless of theme.
+
+// Intents re-tuned for the dark canvas. Looped (below) so each gets the
+// FULL symmetric shade set — the hand blocks used to ship only base+rgb,
+// leaving -light/-dark/-lighter/-darker baked from the LIGHT palette.
+// (primary keeps its hand-tuned block; info stays its light values.)
+$dark-intents: (
+  success: #34c759,
+  warning: #ffcc33,
+  danger: #ff5c5c,
+);
 
 [data-theme='dark'] {
   // Canvas (was `--wr-color-white` in light mode)
@@ -63,14 +75,16 @@
   --wr-color-primary-lighter: #99b6ff;
   --wr-color-primary-darker: #1f3a99;
 
-  --wr-color-success: #34c759;
-  --wr-color-success-rgb: 52, 199, 89;
-
-  --wr-color-warning: #ffcc33;
-  --wr-color-warning-rgb: 255, 204, 51;
-
-  --wr-color-danger: #ff5c5c;
-  --wr-color-danger-rgb: 255, 92, 92;
+  // success / warning / danger — retuned bases now get the FULL symmetric
+  // shade set in dark too (generated, so no intent can silently drift).
+  @each $name, $base in $dark-intents {
+    --wr-color-#{$name}: #{$base};
+    --wr-color-#{$name}-rgb: #{color.channel($base, 'red')}, #{color.channel($base, 'green')}, #{color.channel($base, 'blue')};
+    --wr-color-#{$name}-light: #{color.adjust($base, $lightness: 5%)};
+    --wr-color-#{$name}-lighter: #{color.adjust($base, $lightness: 10%)};
+    --wr-color-#{$name}-dark: #{color.adjust($base, $lightness: -5%)};
+    --wr-color-#{$name}-darker: #{color.adjust($base, $lightness: -10%)};
+  }
 
   // Elevation
   // Black shadows at light-mode alphas vanish on the deep canvas; same

--- a/projects/lib/theme/styles/_focus.scss
+++ b/projects/lib/theme/styles/_focus.scss
@@ -91,3 +91,8 @@
 .wr-dropdown-item:focus-visible {
   @include focus-ring;
 }
+
+// Alert close
+.wr-alert__close:focus-visible {
+  @include focus-ring;
+}

--- a/projects/lib/toast/styles/_index.scss
+++ b/projects/lib/toast/styles/_index.scss
@@ -183,7 +183,7 @@ $toast-colors: (
 
     &:hover {
       color: var(--wr-color-dark);
-      background: rgba(var(--wr-color-light-rgb), 0.5);
+      background: var(--wr-color-hover);
     }
   }
 
@@ -248,7 +248,7 @@ $toast-colors: (
   line-height: 1rem;
   text-align: center;
   cursor: pointer;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  box-shadow: var(--wr-shadow-xs);
   transition:
     color var(--wr-transition-base),
     background var(--wr-transition-base),

--- a/projects/lib/toolbar/styles/_index.scss
+++ b/projects/lib/toolbar/styles/_index.scss
@@ -16,7 +16,7 @@
   background: var(--wr-color-white);
   border: 1px solid var(--wr-color-light);
   @include theme.smooth-br(var(--wr-border-radius-base));
-  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.02);
+  box-shadow: var(--wr-shadow-xs);
   font-family: var(--wr-font-family-base);
   color: var(--wr-color-dark);
 

--- a/projects/lib/tree/styles/_index.scss
+++ b/projects/lib/tree/styles/_index.scss
@@ -33,7 +33,7 @@
     }
 
     &--selected {
-      background: rgba(var(--wr-color-primary-rgb), 0.1);
+      background: var(--wr-color-primary-soft);
       color: var(--wr-color-primary);
     }
 
@@ -224,7 +224,7 @@
     max-width: 100%;
     padding: 0.125rem 0.25rem 0.125rem 0.5rem;
     border-radius: 999px;
-    background: rgba(var(--wr-color-primary-rgb), 0.1);
+    background: var(--wr-color-primary-soft);
     color: var(--wr-color-primary);
     font-size: var(--wr-text-sm);
     line-height: 1.4;
@@ -249,7 +249,7 @@
     transition: background 0.12s ease;
 
     &:hover {
-      background: rgba(var(--wr-color-primary-rgb), 0.2);
+      background: var(--wr-color-primary-active);
     }
   }
 

--- a/projects/lib/tree/styles/_index.scss
+++ b/projects/lib/tree/styles/_index.scss
@@ -29,7 +29,7 @@
       color var(--wr-transition-base);
 
     &:hover:not(.wr-tree__row--disabled) {
-      background: rgba(var(--wr-color-light-rgb), 0.5);
+      background: var(--wr-color-hover);
     }
 
     &--selected {
@@ -40,8 +40,7 @@
     // Visible ring only when the row truly has keyboard focus — not
     // just because it's the roving-tabindex cursor row.
     &:focus-visible {
-      outline: none;
-      box-shadow: 0 0 0 2px rgba(var(--wr-color-primary-rgb), 0.25);
+      @include theme.focus-ring;
     }
 
     &--disabled {
@@ -140,9 +139,8 @@
       box-shadow var(--wr-transition-base);
 
     &:focus-visible {
-      outline: none;
       border-color: var(--wr-color-primary);
-      box-shadow: 0 0 0 3px rgba(var(--wr-color-primary-rgb), 0.15);
+      @include theme.focus-ring;
     }
 
     &:disabled {
@@ -164,7 +162,7 @@
   }
 
   &__placeholder {
-    color: rgba(var(--wr-color-medium-rgb), 0.85);
+    color: var(--wr-color-text-muted);
   }
 
   &__chevron {

--- a/projects/lib/window/styles/_index.scss
+++ b/projects/lib/window/styles/_index.scss
@@ -3,7 +3,7 @@
 .wr-window {
   --wr-window-bg: var(--wr-color-white);
   --wr-window-border: var(--wr-color-light);
-  --wr-window-chrome-bg: rgba(var(--wr-color-light-rgb), 0.4);
+  --wr-window-chrome-bg: var(--wr-color-hover);
   --wr-window-chrome-color: var(--wr-color-dark);
   --wr-window-radius: var(--wr-border-radius-base);
   --wr-window-handle-size: 8px;

--- a/projects/lib/window/styles/_index.scss
+++ b/projects/lib/window/styles/_index.scss
@@ -387,7 +387,7 @@
     }
 
     &:focus-visible {
-      outline: 2px solid var(--wr-color-primary);
+      @include theme.focus-ring;
       outline-offset: 2px;
     }
   }

--- a/projects/lib/window/styles/_index.scss
+++ b/projects/lib/window/styles/_index.scss
@@ -157,7 +157,7 @@
       width: 0.875rem; // 14px — bigger than the prior 12px to match native
       height: 0.875rem;
       border-radius: 50%;
-      color: rgba(0, 0, 0, 0.55); // glyph color (revealed on hover)
+      color: rgba(var(--wr-color-black-rgb), 0.55); // glyph color (revealed on hover)
 
       &--close,
       &--close:hover {

--- a/projects/showcase/app/_layout/footer/footer.ts
+++ b/projects/showcase/app/_layout/footer/footer.ts
@@ -57,6 +57,8 @@ export class Footer {
       links: [
         { label: 'Installation', url: ['/getting-started', 'installation'] },
         { label: 'Theming', url: ['/getting-started', 'theming'] },
+        { label: 'Typography', url: ['/typography'] },
+        { label: 'Translate (i18n)', url: ['/translate'] },
         { label: 'Schematics', url: ['/getting-started', 'schematics'] },
         { label: 'Migration', url: ['/getting-started', 'changelog'] },
       ],
@@ -64,11 +66,20 @@ export class Footer {
     {
       title: 'Catalog',
       links: [
-        { label: 'Components', url: ['/components', 'button'] },
-        { label: 'Directives', url: ['/directives', 'border-glow'] },
-        { label: 'Pipes', url: ['/pipes', 'wr-t'] },
-        { label: 'Services', url: ['/services', 'storage'] },
-        { label: 'Icons', url: ['/icons', 'lucide'] },
+        { label: 'Components', url: ['/components'] },
+        { label: 'Directives', url: ['/directives'] },
+        { label: 'Animations', url: ['/animations'] },
+        { label: 'Icons', url: ['/icons'] },
+      ],
+    },
+    {
+      title: 'API',
+      links: [
+        { label: 'Pipes', url: ['/pipes'] },
+        { label: 'Services', url: ['/services'] },
+        { label: 'Utils', url: ['/utils'] },
+        { label: 'Interfaces', url: ['/interfaces'] },
+        { label: 'Validators', url: ['/validators'] },
       ],
     },
     {

--- a/projects/showcase/app/_layout/footer/footer.ts
+++ b/projects/showcase/app/_layout/footer/footer.ts
@@ -70,11 +70,6 @@ export class Footer {
         { label: 'Directives', url: ['/directives'] },
         { label: 'Animations', url: ['/animations'] },
         { label: 'Icons', url: ['/icons'] },
-      ],
-    },
-    {
-      title: 'API',
-      links: [
         { label: 'Pipes', url: ['/pipes'] },
         { label: 'Services', url: ['/services'] },
         { label: 'Utils', url: ['/utils'] },

--- a/projects/showcase/app/components/alert/alert.html
+++ b/projects/showcase/app/components/alert/alert.html
@@ -1,6 +1,6 @@
 <ngwr-doc-page
   title="Alert"
-  description="Inline status banner — info, success, warning, danger."
+  description="Inline status banner — info, success, warning, danger, neutral, offline."
   [keywords]="['alert', 'banner', 'wr-alert']"
   [labels]="['Component', 'Standalone']"
 >
@@ -22,6 +22,34 @@
         @for (t of types; track t) {
           <wr-alert [title]="t" message="Sample message" [type]="t" />
         }
+      </div>
+    </ngwr-doc-snippet>
+  </ngwr-doc-section>
+
+  <ngwr-doc-section title="With title" description="Pair a `title` with a secondary `message`.">
+    <ngwr-doc-snippet [code]="snippets.withTitle">
+      <div style="width: 100%">
+        <wr-alert title="Update available" message="Version 2.0 is ready to install." type="info" />
+      </div>
+    </ngwr-doc-snippet>
+  </ngwr-doc-section>
+
+  <ngwr-doc-section
+    title="Without title"
+    description="Omit `title` and the `message` renders as a single primary line."
+  >
+    <ngwr-doc-snippet [code]="snippets.noTitle">
+      <div style="display: flex; flex-direction: column; gap: 0.5rem; width: 100%">
+        <wr-alert message="Your changes are live." type="success" />
+        <wr-alert message="Connection lost." type="offline" />
+      </div>
+    </ngwr-doc-snippet>
+  </ngwr-doc-section>
+
+  <ngwr-doc-section title="Custom icon" description="Override the default per-type icon with `iconName`.">
+    <ngwr-doc-snippet [code]="snippets.customIcon">
+      <div style="width: 100%">
+        <wr-alert iconName="sparkles" title="What's new" message="Smarter search just landed." />
       </div>
     </ngwr-doc-snippet>
   </ngwr-doc-section>

--- a/projects/showcase/app/components/alert/alert.ts
+++ b/projects/showcase/app/components/alert/alert.ts
@@ -1,6 +1,9 @@
 import { Component } from '@angular/core';
 
+import { Sparkles } from 'lucide';
 import { WrAlert, type WrAlertType } from 'ngwr/alert';
+import { provideWrIcons } from 'ngwr/icon';
+import { lucideIcons } from 'ngwr/icon/adapters/lucide';
 
 import {
   DocApiComponent,
@@ -15,9 +18,10 @@ import {
   selector: 'ngwr-alert-page',
   templateUrl: './alert.html',
   imports: [WrAlert, DocPageComponent, DocSectionComponent, DocSnippetComponent, DocCodeComponent, DocApiComponent],
+  providers: [provideWrIcons(lucideIcons({ sparkles: Sparkles }))],
 })
 export default class AlertComponent {
-  protected readonly types: readonly WrAlertType[] = ['info', 'success', 'warning', 'danger'];
+  protected readonly types: readonly WrAlertType[] = ['info', 'success', 'warning', 'danger', 'neutral', 'offline'];
 
   protected readonly snippets = {
     install: `import { WrAlert } from 'ngwr/alert';
@@ -28,15 +32,32 @@ export class MyComponent {}`,
     types: `<wr-alert title="Info" type="info" />
 <wr-alert title="Success" type="success" />
 <wr-alert title="Warning" type="warning" />
-<wr-alert title="Danger" type="danger" />`,
+<wr-alert title="Danger" type="danger" />
+<wr-alert title="Neutral" type="neutral" />
+<wr-alert title="Offline" type="offline" />`,
+    withTitle: `<wr-alert title="Update available" message="Version 2.0 is ready to install." type="info" />`,
+    noTitle: `<wr-alert message="Your changes are live." type="success" />
+<wr-alert message="Connection lost." type="offline" />`,
+    customIcon: `<wr-alert iconName="sparkles" title="What's new" message="Smarter search just landed." />`,
     closeable: `<wr-alert title="Saved" type="success" closeable (closed)="onClose()" />`,
     noIcon: `<wr-alert title="Plain" message="No leading icon." [icon]="false" />`,
   };
 
   protected readonly api: readonly DocApiRow[] = [
-    { name: 'title', description: 'Headline.', type: 'string', required: true },
-    { name: 'type', description: 'Visual variant.', type: 'WrAlertType', default: "'info'" },
+    { name: 'title', description: 'Optional headline.', type: 'string | null', default: 'null' },
+    {
+      name: 'type',
+      description: 'Visual variant.',
+      type: "'info' | 'success' | 'warning' | 'danger' | 'neutral' | 'offline'",
+      default: "'info'",
+    },
     { name: 'message', description: 'Optional secondary message.', type: 'string | null', default: 'null' },
+    {
+      name: 'iconName',
+      description: 'Override the default per-type icon with any ngwr icon name.',
+      type: 'WrIconName | null',
+      default: 'null',
+    },
     {
       name: 'icon',
       description: 'Show a leading status icon matching the `type`. Pass `false` to hide.',

--- a/projects/showcase/app/getting-started/configuration/configuration.ts
+++ b/projects/showcase/app/getting-started/configuration/configuration.ts
@@ -38,7 +38,7 @@ bootstrapApplication(AppComponent, {
     provideWrIcons(lucideIcons({ plus: Plus, trash: Trash2 })),
     provideWrToast(),
     provideWrTheme({ defaultMode: 'auto' }),
-    provideWrDensity({ preset: 'comfortable' }),
+    provideWrDensity({ defaultDensity: 'lg' }),
     provideWrDateAdapter(),
     provideWrLoadingBar(),
     provideWrI18n(),
@@ -95,8 +95,8 @@ providers: [provideWrDateAdapter({ adapter: WrLuxonAdapter })],`,
 
     density: `import { provideWrDensity } from 'ngwr/density';
 
-// Comfortable (default), compact, or custom multipliers.
-providers: [provideWrDensity({ preset: 'compact' })],
+// App-wide default density: 'sm' | 'md' (default) | 'lg' | 'touch'.
+providers: [provideWrDensity({ defaultDensity: 'sm' })],
 
 // Fine-grained:
 providers: [provideWrDensity({ height: 0.875, padding: 0.75 })],`,

--- a/projects/showcase/app/getting-started/mobile/mobile.ts
+++ b/projects/showcase/app/getting-started/mobile/mobile.ts
@@ -35,7 +35,7 @@ this.dialog.open(EditProfile, { responsive: true });`,
 <wr-table responsive [columns]="cols" [items]="rows" />`,
     density: `import { provideWrDensity } from 'ngwr/density';
 
-// App-wide default — compact | default | comfortable | touch.
+// App-wide default — sm | md | lg | touch.
 provideWrDensity({ defaultDensity: 'touch' });
 
 // …or scope it to a subtree with the directive:

--- a/projects/showcase/app/getting-started/theming/theming.html
+++ b/projects/showcase/app/getting-started/theming/theming.html
@@ -69,7 +69,7 @@
 
   <ngwr-doc-section
     title="Density"
-    description="A spacing scale — compact / default / comfortable — applied via CSS-variable multipliers. Components like button, input, select, table, list automatically pick it up."
+    description="A spacing scale — sm / md / lg (+ touch) — applied via CSS-variable multipliers. Components like button, input, select, table, list automatically pick it up."
   >
     <ngwr-doc-snippet code="">
       <div style="display: flex; flex-direction: column; gap: 0.5rem; align-items: flex-start">

--- a/projects/showcase/app/getting-started/theming/theming.ts
+++ b/projects/showcase/app/getting-started/theming/theming.ts
@@ -21,7 +21,7 @@ export default class ThemingPage {
   protected readonly densityCurrent = this.density.current;
 
   protected readonly modes: readonly WrThemeMode[] = ['light', 'dark', 'auto'];
-  protected readonly densities: readonly WrDensityValue[] = ['compact', 'default', 'comfortable'];
+  protected readonly densities: readonly WrDensityValue[] = ['sm', 'md', 'lg'];
 
   protected setMode(mode: WrThemeMode): void {
     this.theme.set(mode);
@@ -39,7 +39,7 @@ import { provideWrDensity } from 'ngwr/density';
 bootstrapApplication(AppComponent, {
   providers: [
     provideWrTheme({ defaultMode: 'auto' }),  // 'light' | 'dark' | 'auto'
-    provideWrDensity({ defaultDensity: 'default' }),
+    provideWrDensity({ defaultDensity: 'md' }),  // 'sm' | 'md' | 'lg' | 'touch'
   ],
 });`,
 
@@ -165,8 +165,8 @@ providers: [provideWrIcons([dragon])],
   --wr-icon-size: 1rem;
 }`,
 
-    densityScope: `<!-- Compact toolbar inside a default-density page. -->
-<aside wrDensity="compact">
+    densityScope: `<!-- sm toolbar inside an md-density page. -->
+<aside wrDensity="sm">
   <button wr-btn>Action</button>
   <input wrInput placeholder="…" />
 </aside>

--- a/projects/showcase/app/home/components-bento/components-bento.html
+++ b/projects/showcase/app/home/components-bento/components-bento.html
@@ -106,26 +106,15 @@
         </div>
       </article>
 
-      <!-- Tile 5 — Toast preview -->
+      <!-- Tile 5 — Alert -->
       <article class="ngwr-cbento__tile">
         <header class="ngwr-cbento__tile-head">
           <p wrTypography variant="h5">Notification</p>
-          <p wrTypography variant="caption" tone="medium">Toast surface</p>
+          <p wrTypography variant="caption" tone="medium">Alert surface</p>
         </header>
-        <div class="ngwr-cbento__tile-body ngwr-cbento__toasts">
-          <div class="ngwr-cbento__toast ngwr-cbento__toast--success">
-            <wr-icon name="checkmark" />
-            <div>
-              <p wrTypography variant="small">Payment received</p>
-              <p wrTypography variant="caption" tone="medium">$129.99 from Roman</p>
-            </div>
-          </div>
-          <div class="ngwr-cbento__toast">
-            <div>
-              <p wrTypography variant="small">2 new comments</p>
-              <p wrTypography variant="caption" tone="medium">View thread</p>
-            </div>
-          </div>
+        <div class="ngwr-cbento__tile-body ngwr-cbento__alerts">
+          <wr-alert type="success" title="Payment received" message="$129.99 from Roman" />
+          <wr-alert type="info" title="2 new comments" message="View thread" />
         </div>
       </article>
 

--- a/projects/showcase/app/home/components-bento/components-bento.scss
+++ b/projects/showcase/app/home/components-bento/components-bento.scss
@@ -283,37 +283,8 @@
     }
   }
 
-  &__toasts {
+  &__alerts {
     gap: 0.5rem;
-  }
-
-  &__toast {
-    display: flex;
-    align-items: flex-start;
-    gap: 0.625rem;
-    padding: 0.625rem 0.75rem;
-    background: var(--wr-color-white);
-    border: 1px solid var(--wr-color-light);
-    border-radius: var(--wr-border-radius-base);
-    box-shadow: var(--wr-shadow-xs);
-
-    > div {
-      display: flex;
-      flex-direction: column;
-      gap: 0.125rem;
-      min-width: 0;
-    }
-
-    --wr-icon-size: 1rem;
-
-    &--success {
-      border-left: 3px solid var(--wr-color-success);
-
-      wr-icon {
-        color: var(--wr-color-success);
-        margin-top: 0.125rem;
-      }
-    }
   }
 
   &__empty {

--- a/projects/showcase/app/home/components-bento/components-bento.ts
+++ b/projects/showcase/app/home/components-bento/components-bento.ts
@@ -9,6 +9,7 @@ import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/cor
 import { FormsModule } from '@angular/forms';
 
 import { Check, CreditCard, Folder, House, Settings } from 'lucide';
+import { WrAlert } from 'ngwr/alert';
 import { WrAvatar } from 'ngwr/avatar';
 import { WrBadge, WrTag } from 'ngwr/badge';
 import { WrButton } from 'ngwr/button';
@@ -37,6 +38,7 @@ import { DocCodeComponent } from '#core/components';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     FormsModule,
+    WrAlert,
     WrAvatar,
     WrBadge,
     WrButton,

--- a/projects/showcase/app/home/home.html
+++ b/projects/showcase/app/home/home.html
@@ -221,14 +221,7 @@
       </div>
 
       <div class="ngwr-motion-footer">
-        <a
-          wr-btn
-          outlined
-          size="lg"
-          [routerLink]="['/animations', 'border-glow']"
-          icon="arrow-forward"
-          iconPosition="end"
-        >
+        <a wr-btn outlined size="lg" [routerLink]="['/animations']" icon="arrow-forward" iconPosition="end">
           Browse the kit
         </a>
       </div>

--- a/projects/showcase/app/home/home.ts
+++ b/projects/showcase/app/home/home.ts
@@ -191,7 +191,7 @@ export class SignupCard {
 
     const meta = inject(MetaService);
     meta.setCanonicalURL();
-    meta.setTitle(null);
+    meta.setTitle('Angular UI components library');
     meta.setDescription(
       'ngwr — standalone, signals-first Angular components. Token-driven theming, a11y in the lib, dark mode first.'
     );

--- a/projects/showcase/app/services/density/density.html
+++ b/projects/showcase/app/services/density/density.html
@@ -43,11 +43,11 @@
 
   <ngwr-doc-section
     title="Per-subtree override"
-    description="Drop `[wrDensity]` on any element to scope an override. The toolbar below stays compact regardless of the page's global density."
+    description="Drop `[wrDensity]` on any element to scope an override. The toolbar below stays sm regardless of the page's global density."
   >
     <ngwr-doc-snippet [code]="snippets.directive">
       <div
-        wrDensity="compact"
+        wrDensity="sm"
         style="
           display: flex;
           gap: 0.5rem;

--- a/projects/showcase/app/services/density/density.ts
+++ b/projects/showcase/app/services/density/density.ts
@@ -41,7 +41,7 @@ export default class DensityServicePage {
   private readonly density = inject(WrDensity);
 
   protected readonly current = this.density.current;
-  protected readonly modes: readonly WrDensityValue[] = ['compact', 'default', 'comfortable', 'touch'];
+  protected readonly modes: readonly WrDensityValue[] = ['sm', 'md', 'lg', 'touch'];
 
   protected readonly demoSelect = new FormControl<string>('sm', { nonNullable: true });
 
@@ -54,20 +54,20 @@ export default class DensityServicePage {
 
 bootstrapApplication(AppComponent, {
   providers: [
-    provideWrDensity({ defaultDensity: 'compact' }),
+    provideWrDensity({ defaultDensity: 'sm' }),
   ],
 });
 
 // Switch it later:
 const density = inject(WrDensity);
-density.set('comfortable');
+density.set('lg');
 density.cycle();`,
-    directive: `<!-- Scope an override to a subtree — descendants get compact, the rest of the app keeps the global value. -->
-<aside wrDensity="compact">
+    directive: `<!-- Scope an override to a subtree — descendants get sm, the rest of the app keeps the global value. -->
+<aside wrDensity="sm">
   <wr-list ...></wr-list>
 </aside>`,
     tokens: `/* Override the multipliers in your own stylesheet. */
-[data-wr-density='compact'] {
+[data-wr-density='sm'] {
   --wr-density-y: 0.5;     /* even tighter vertical padding */
   --wr-density-x: 0.8;
 }`,


### PR DESCRIPTION
⚠️ **BREAKING CHANGE**: density values renamed from `compact`/`default`/`comfortable` to `sm`/`md`/`lg` — affects `WrDensityValue`, `provideWrDensity({ defaultDensity })`, `[data-wr-density]`, and the `ng-add` schematic. `touch` is unchanged; the default is now `md`.

## Theming & colors
- soft tint tokens (`-soft`/`-soft-border`/`-soft-contrast`), real `info` intent, symmetric dark shades
- new shared tokens: `border{,-subtle,-strong}`, `overlay`, `{intent}-active`, `text-{muted,faint}`
- alert: full-border redesign + `neutral`/`offline` types + custom icon
- toast: tokenized hover + shadow

## Token sweep (single source / no hardcoded colours)
- 35 magic colour/shadow values across 25 components → shared tokens
- 15 literal `rgb(0 0 0)`/`rgb(255 255 255)` → `--wr-color-black/white-rgb`
- 14 inline focus rings → central `@mixin focus-ring`; row-hover unified; muted-text tokenized

## Showcase
- home bento uses `<wr-alert>`; "browse the kit" → /animations; footer nav; home `<title>`