### PR TITLE
feat(checkbox)!: migrate off cva to signal forms

### DIFF
--- a/projects/lib/checkbox/checkbox-group.ts
+++ b/projects/lib/checkbox/checkbox-group.ts
@@ -22,9 +22,9 @@ import { WR_CHECKBOX_GROUP, type WrCheckboxGroupContext } from './tokens';
  * @example
  * ```html
  * <wr-checkbox-group [formField]="form.features">
- *   <wr-checkbox value="autosave">Autosave</wr-checkbox>
- *   <wr-checkbox value="notifications">Notifications</wr-checkbox>
- *   <wr-checkbox value="darkmode">Dark mode</wr-checkbox>
+ *   <wr-checkbox checkboxValue="autosave">Autosave</wr-checkbox>
+ *   <wr-checkbox checkboxValue="notifications">Notifications</wr-checkbox>
+ *   <wr-checkbox checkboxValue="darkmode">Dark mode</wr-checkbox>
  * </wr-checkbox-group>
  * ```
  *

--- a/projects/lib/checkbox/checkbox.html
+++ b/projects/lib/checkbox/checkbox.html
@@ -3,7 +3,7 @@
     class="wr-checkbox__input"
     type="checkbox"
     [id]="id()"
-    [checked]="checked()"
+    [checked]="isChecked()"
     [indeterminate]="indeterminate()"
     [disabled]="effectiveDisabled()"
     (change)="onInputChange($event)"

--- a/projects/lib/checkbox/checkbox.ts
+++ b/projects/lib/checkbox/checkbox.ts
@@ -6,40 +6,41 @@
  */
 
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
-import { Component, ViewEncapsulation, computed, forwardRef, inject, input, signal } from '@angular/core';
-import { type ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { Component, ViewEncapsulation, computed, inject, input, model, output } from '@angular/core';
+import type { FormCheckboxControl } from '@angular/forms/signals';
 
 import { WrIcon, type WrIconName } from 'ngwr/icon';
-import { noop, randomId } from 'ngwr/utils';
+import { randomId } from 'ngwr/utils';
 
 import { WR_CHECKBOX_GROUP } from './tokens';
 
 /**
  * Two-state checkbox.
  *
- * **Standalone mode** — boolean value, works as a `ControlValueAccessor`:
+ * A signal-forms native control: it implements `FormCheckboxControl`, so
+ * `[formField]` binds straight to its `checked` model — no
+ * `ControlValueAccessor` in between. `[(checked)]` works standalone, and
+ * classic `[(ngModel)]` / reactive forms keep working through Angular's bridge.
  *
  * @example
  * ```html
- * <wr-checkbox [(ngModel)]="agree">I agree</wr-checkbox>
+ * <wr-checkbox [(checked)]="agree">I agree</wr-checkbox>
+ * <wr-checkbox [formField]="form.agree">I agree</wr-checkbox>
  * ```
  *
- * **Inside `<wr-checkbox-group>`** — the checkbox's `value` is added to
- * or removed from the group's array. The standalone CVA is ignored.
+ * **Inside `<wr-checkbox-group>`** — the checkbox's `checkboxValue` is added to
+ * or removed from the group's array, and the group is the native form control.
+ * (The identity input is `checkboxValue`, not `value`, because
+ * `FormCheckboxControl` reserves `value` — its form state is the boolean
+ * `checked`.)
  *
  * @example
  * ```html
  * <wr-checkbox-group [formField]="form.features">
- *   <wr-checkbox value="autosave">Autosave</wr-checkbox>
- *   <wr-checkbox value="notifications">Notifications</wr-checkbox>
+ *   <wr-checkbox checkboxValue="autosave">Autosave</wr-checkbox>
+ *   <wr-checkbox checkboxValue="notifications">Notifications</wr-checkbox>
  * </wr-checkbox-group>
  * ```
- *
- * Unlike the other value controls, the standalone checkbox stays a
- * `ControlValueAccessor` rather than a signal-forms `FormCheckboxControl`:
- * that contract forbids a `value` property, but `value` is this component's
- * group-membership identity. Both `[formField]` and `[(ngModel)]` still work
- * on it through Angular's CVA bridge; the group is the native form control.
  *
  * @see https://ngwr.dev/reference/components/checkbox
  */
@@ -51,16 +52,8 @@ export type WrCheckboxSize = 'sm' | 'md' | 'lg';
   encapsulation: ViewEncapsulation.None,
   host: { '[class]': 'classes()' },
   imports: [WrIcon],
-  providers: [
-    {
-      provide: NG_VALUE_ACCESSOR,
-      // eslint-disable-next-line @angular-eslint/no-forward-ref
-      useExisting: forwardRef(() => WrCheckbox),
-      multi: true,
-    },
-  ],
 })
-export class WrCheckbox implements ControlValueAccessor {
+export class WrCheckbox implements FormCheckboxControl {
   /**
    * Stable id used to associate the native input with its label.
    *
@@ -69,13 +62,26 @@ export class WrCheckbox implements ControlValueAccessor {
   readonly id = input<string>(randomId('wr-checkbox'));
 
   /**
-   * Per-checkbox value used only when inside a `<wr-checkbox-group>`.
-   * Ignored in standalone mode.
+   * This checkbox's identity when inside a `<wr-checkbox-group>` — the value
+   * added to / removed from the group's array. Ignored in standalone mode.
+   * (Named `checkboxValue`, not `value`, because `FormCheckboxControl` reserves
+   * `value`.)
    */
-  readonly value = input<unknown>(null);
+  readonly checkboxValue = input<unknown>(null);
 
   /**
-   * Disable the checkbox. Also set automatically by Angular forms.
+   * Checked state — the form value. Bound by `[formField]`, two-way via
+   * `[(checked)]`, or `[(ngModel)]`. Ignored inside a `<wr-checkbox-group>`,
+   * where the group's array is the source of truth.
+   */
+  readonly checked = model<boolean>(false);
+
+  /** Emitted on blur so a bound field can mark itself touched. */
+  readonly touch = output<void>();
+
+  /**
+   * Disable the checkbox. Bound automatically from the field's disabled state
+   * when used with `[formField]`.
    *
    * @default false
    */
@@ -102,19 +108,15 @@ export class WrCheckbox implements ControlValueAccessor {
 
   private readonly group = inject(WR_CHECKBOX_GROUP, { optional: true });
 
-  // Standalone state. When inside a group, these are not used as the source of truth.
-  protected readonly standaloneChecked = signal(false);
-  protected readonly standaloneDisabledFromCva = signal(false);
+  /** Rendered "is checked" — reads the group when grouped, else the `checked` model. */
+  protected readonly isChecked = computed(() =>
+    this.group ? this.group.isSelected(this.checkboxValue()) : this.checked()
+  );
 
-  /** Derived "is checked". Reads from group when grouped, else local state. */
-  protected readonly checked = computed(() => {
-    return this.group ? this.group.isSelected(this.value()) : this.standaloneChecked();
-  });
-
-  /** Effective disabled — input wins, then group, then CVA. */
+  /** Effective disabled — the `disabled` input wins, then the group. */
   protected readonly effectiveDisabled = computed(() => {
     if (this.disabled()) return true;
-    return this.group ? this.group.isDisabled() : this.standaloneDisabledFromCva();
+    return this.group ? this.group.isDisabled() : false;
   });
 
   protected readonly classes = computed(() => {
@@ -122,45 +124,22 @@ export class WrCheckbox implements ControlValueAccessor {
     const size = this.size();
     if (size !== 'md') parts.push(`wr-checkbox--${size}`);
     if (this.indeterminate()) parts.push('wr-checkbox--indeterminate');
-    else if (this.checked()) parts.push('wr-checkbox--checked');
+    else if (this.isChecked()) parts.push('wr-checkbox--checked');
     if (this.effectiveDisabled()) parts.push('wr-checkbox--disabled');
     return parts.join(' ');
   });
 
-  private onChange: (value: boolean) => void = noop;
-  private onTouched: () => void = noop;
-
-  // ControlValueAccessor (standalone mode)
-
-  writeValue(value: boolean | null): void {
-    this.standaloneChecked.set(!!value);
-  }
-
-  registerOnChange(fn: (value: boolean) => void): void {
-    this.onChange = fn;
-  }
-
-  registerOnTouched(fn: () => void): void {
-    this.onTouched = fn;
-  }
-
-  setDisabledState(isDisabled: boolean): void {
-    this.standaloneDisabledFromCva.set(coerceBooleanProperty(isDisabled));
-  }
-
   // Template handlers
 
   protected onInputChange(event: Event): void {
-    const checked = (event.target as HTMLInputElement).checked;
     if (this.group) {
-      this.group.toggle(this.value());
+      this.group.toggle(this.checkboxValue());
       return;
     }
-    this.standaloneChecked.set(checked);
-    this.onChange(checked);
+    this.checked.set((event.target as HTMLInputElement).checked);
   }
 
   protected onInputBlur(): void {
-    this.onTouched();
+    this.touch.emit();
   }
 }

--- a/projects/lib/schematics/migrations.json
+++ b/projects/lib/schematics/migrations.json
@@ -10,6 +10,11 @@
       "version": "8.0.0",
       "description": "Rename density values compact/default/comfortable \u2192 sm/md/lg (wrDensity, provideWrDensity defaultDensity, [data-wr-density]); pagination size xs/xl \u2192 sm/lg. Warns about removed APIs (WrReveal directive, WrScrambleText / ngwr/scramble-text) that need manual migration. Touches .html, .ts, and .scss files.",
       "factory": "./migrations/v8/index#default"
+    },
+    "migration-v9": {
+      "version": "9.0.0",
+      "description": "Rename the <wr-checkbox> group-membership input value \u2192 checkboxValue (also [value] / [(value)]). The standalone checkbox is now a signal-forms FormCheckboxControl whose contract reserves `value` for the form value \u2014 its boolean state is the `checked` model. Touches .html and .ts files.",
+      "factory": "./migrations/v9/index#default"
     }
   }
 }

--- a/projects/lib/schematics/migrations/v9/index.ts
+++ b/projects/lib/schematics/migrations/v9/index.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/thekhegay/ngwr/blob/main/LICENSE
+ */
+
+import type { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+
+/**
+ * v8 → v9 migration.
+ *
+ * Auto-fixed (safe, element-scoped regexes):
+ *   `<wr-checkbox value="…">` → `checkboxValue="…"` (also `[value]` / `[(value)]`).
+ *
+ * The standalone checkbox is now a signal-forms native `FormCheckboxControl`,
+ * whose contract reserves `value` for the form value — so the group-membership
+ * identity moved to `checkboxValue`. This rename matters especially because the
+ * STATIC form fails silently: `<wr-checkbox value="x">` raises no template
+ * error, it just lands on the host as a plain DOM attribute, leaving every child
+ * in a group with the default identity (`null`) — so they'd all toggle together.
+ *
+ * Regex-based + dependency-free, matching the v7 / v8 migrations. The pattern is
+ * anchored to the `<wr-checkbox` element and tolerates attributes and newlines
+ * before the match, so `value` on any other element is untouched. Verify with
+ * `git diff` afterwards.
+ */
+
+interface Transform {
+  readonly pattern: RegExp;
+  readonly replacement: string;
+}
+
+/**
+ * Match `value` / `[value]` / `[(value)]` inside a `<wr-checkbox …>` open tag.
+ * `[^>]*?` stays inside the tag (it can't cross `>`), so the rename never
+ * escapes the element it's scoped to.
+ */
+const HTML_TRANSFORMS: readonly Transform[] = [
+  // <wr-checkbox … value="x">  →  checkboxValue="x"
+  { pattern: /(<wr-checkbox\b[^>]*?\s)value=/g, replacement: '$1checkboxValue=' },
+  // <wr-checkbox … [value]="x">  →  [checkboxValue]="x"
+  { pattern: /(<wr-checkbox\b[^>]*?\s)\[value\]=/g, replacement: '$1[checkboxValue]=' },
+  // <wr-checkbox … [(value)]="x">  →  [(checkboxValue)]="x"
+  { pattern: /(<wr-checkbox\b[^>]*?\s)\[\(value\)\]=/g, replacement: '$1[(checkboxValue)]=' },
+];
+
+const IGNORE_DIRS = new Set(['node_modules', 'dist', '.git', '.cache', '.angular', 'coverage', '.next', '.nuxt']);
+
+function ngUpdateV9(): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    let html = 0;
+
+    visit(tree, '/', filePath => {
+      const lower = filePath.toLowerCase();
+      // Inline templates live in .ts files too, so run the same element-scoped
+      // transforms there.
+      if (!lower.endsWith('.html') && !lower.endsWith('.ts')) return;
+
+      const original = tree.readText(filePath);
+      const next = apply(original, HTML_TRANSFORMS);
+
+      if (next !== original) {
+        tree.overwrite(filePath, next);
+        html += 1;
+      }
+    });
+
+    context.logger.info(
+      `ngwr v9 migration: rewrote ${html} file(s) (<wr-checkbox> value → checkboxValue).\n` +
+        'The standalone checkbox is now a signal-forms FormCheckboxControl: its form value is the ' +
+        'boolean `checked` model ([(checked)] / [formField] / [(ngModel)]), and the group-membership ' +
+        'identity is `checkboxValue`.'
+    );
+    context.logger.info('Verify the result with `git diff` — a few edge cases may need manual touch-up.');
+    return tree;
+  };
+}
+
+function apply(content: string, transforms: readonly Transform[]): string {
+  let next = content;
+  for (const { pattern, replacement } of transforms) {
+    next = next.replace(pattern, replacement);
+  }
+  return next;
+}
+
+function visit(tree: Tree, dir: string, visitor: (filePath: string) => void): void {
+  const entry = tree.getDir(dir);
+  for (const file of entry.subfiles) {
+    visitor(`${dir === '/' ? '' : dir}/${file}`);
+  }
+  for (const sub of entry.subdirs) {
+    if (IGNORE_DIRS.has(sub)) continue;
+    visit(tree, `${dir === '/' ? '' : dir}/${sub}`, visitor);
+  }
+}
+
+export default ngUpdateV9;

--- a/projects/showcase/app/reference/components/checkbox/checkbox.html
+++ b/projects/showcase/app/reference/components/checkbox/checkbox.html
@@ -8,9 +8,12 @@
     <ngwr-doc-code [code]="snippets.install" language="angular-ts" />
   </ngwr-doc-section>
 
-  <ngwr-doc-section title="Standalone" description="Boolean value via [(ngModel)] or formControl.">
+  <ngwr-doc-section
+    title="Standalone"
+    description="Signal-forms native — bind the boolean `checked` model via `[(checked)]`, `[formField]`, or classic `[(ngModel)]`."
+  >
     <ngwr-doc-snippet [code]="snippets.standalone">
-      <wr-checkbox [(ngModel)]="agree">I agree to the terms</wr-checkbox>
+      <wr-checkbox [(checked)]="agree">I agree to the terms</wr-checkbox>
       <span style="color: var(--wr-color-medium); font-size: 0.875rem">Value: {{ agree() }}</span>
     </ngwr-doc-snippet>
   </ngwr-doc-section>
@@ -22,9 +25,9 @@
     <ngwr-doc-snippet [code]="snippets.group">
       <div style="display: flex; flex-direction: column; gap: 0.75rem; width: 100%">
         <wr-checkbox-group [(ngModel)]="features">
-          <wr-checkbox value="autosave">Autosave</wr-checkbox>
-          <wr-checkbox value="notifications">Notifications</wr-checkbox>
-          <wr-checkbox value="darkmode">Dark mode</wr-checkbox>
+          <wr-checkbox checkboxValue="autosave">Autosave</wr-checkbox>
+          <wr-checkbox checkboxValue="notifications">Notifications</wr-checkbox>
+          <wr-checkbox checkboxValue="darkmode">Dark mode</wr-checkbox>
         </wr-checkbox-group>
         <span style="color: var(--wr-color-medium); font-size: 0.875rem">Value: [{{ features().join(', ') }}]</span>
       </div>

--- a/projects/showcase/app/reference/components/checkbox/checkbox.ts
+++ b/projects/showcase/app/reference/components/checkbox/checkbox.ts
@@ -36,11 +36,12 @@ import { FormsModule } from '@angular/forms';
 
 @Component({ imports: [WrCheckbox, WrCheckboxGroup, FormsModule] })
 export class MyComponent {}`,
-    standalone: `<wr-checkbox [(ngModel)]="agree">I agree</wr-checkbox>`,
+    standalone: `<!-- signal-forms native: [(checked)], [formField], or classic [(ngModel)] -->
+<wr-checkbox [(checked)]="agree">I agree</wr-checkbox>`,
     group: `<wr-checkbox-group [(ngModel)]="features">
-  <wr-checkbox value="autosave">Autosave</wr-checkbox>
-  <wr-checkbox value="notifications">Notifications</wr-checkbox>
-  <wr-checkbox value="darkmode">Dark mode</wr-checkbox>
+  <wr-checkbox checkboxValue="autosave">Autosave</wr-checkbox>
+  <wr-checkbox checkboxValue="notifications">Notifications</wr-checkbox>
+  <wr-checkbox checkboxValue="darkmode">Dark mode</wr-checkbox>
 </wr-checkbox-group>`,
     disabled: `<wr-checkbox [disabled]="true">Disabled</wr-checkbox>`,
     indeterminate: `<!-- A parent "select all": mixed when only some children are checked. -->
@@ -68,7 +69,24 @@ export class MyComponent {}`,
 
   protected readonly api: readonly DocApiRow[] = [
     { name: 'id', description: 'Stable id for the native input.', type: 'string', default: 'auto' },
-    { name: 'value', description: 'Used only inside <wr-checkbox-group>.', type: 'unknown', default: 'null' },
+    {
+      name: 'checked',
+      description: 'Checked state — the form value (two-way; [formField] / [(ngModel)] also bind it).',
+      type: 'boolean',
+      default: 'false',
+    },
+    {
+      name: 'checkboxValue',
+      description: 'Identity inside <wr-checkbox-group>. (Named checkboxValue — FormCheckboxControl reserves `value`.)',
+      type: 'unknown',
+      default: 'null',
+    },
+    {
+      name: '(touch)',
+      description: 'Emitted on blur so a bound field can mark itself touched.',
+      type: 'OutputRef<void>',
+      default: '—',
+    },
     {
       name: 'size',
       description: 'Control size, shares the --wr-control-* contract.',


### PR DESCRIPTION
BREAKING CHANGE: the <wr-checkbox> group-membership input is renamed `value` → `checkboxValue`, because the signal-forms `FormCheckboxControl` contract reserves `value` (its form value is the boolean `checked` model). Run `ng update ngwr@9` — the migration-v9 schematic rewrites `value=`, `[value]=` and `[(value)]=` on <wr-checkbox> elements automatically. The static form `<wr-checkbox value="x">` fails SILENTLY otherwise (it becomes a plain DOM attribute), so run the migration.